### PR TITLE
Add support for multi-line includes

### DIFF
--- a/abl.tmLanguage.json
+++ b/abl.tmLanguage.json
@@ -2868,48 +2868,69 @@
       "name": "variable.parameter.abl"
     },
     "include-file": {
-      "begin": "({)\\s*",
+      "name": "meta.include.abl",
+      "comment": "https://docs.progress.com/bundle/openedge-abl-reference-122/page/Include-file-reference.html",
+      "begin": "(?i)({)\\s*(([a-z][a-z0-9\\/\\-\\_\\\\]+)(\\.[a-z]+)?)",
       "beginCaptures": {
         "1": {
           "name": "punctuation.section.abl"
+        },
+        "2": {
+          "name": "meta.other.include.abl"
         }
       },
-      "end": "\\s*(})",
+      "end": "\\s*(})\\s*",
       "endCaptures": {
         "1": {
           "name": "punctuation.section.abl"
         }
       },
-      "name": "meta.include.abl",
       "patterns": [
+        {
+          "include": "#argument-reference"
+        },
+        {
+          "match": "(?<=\\s)(&[a-zA-Z][a-zA-Z0-9\\#\\$\\-\\_\\%\\.]+)\\s*(=?)",
+          "name": "meta.include.argument.abl",
+          "comment": "This is intended to catch '&arg' and '&arg=' ",
+          "captures": {
+            "1": {
+              "name": "support.other.argument.abl",
+              "comment": "you can use variable names, field names, and reserved words as argument names."
+            },
+            "2": {
+              "name": "keyword.operator.source.abl"
+            }
+          }
+        },
         {
           "include": "#string"
         },
         {
-          "match": "(?i)({\\&[\\w-]*})",
-          "name": "keyword.other"
-        },
-        {
-          "match": "(\\&[\\w-]+)(\\s*)=(\\s*)((\".*\")|('.*')|([^}\\s]*))",
-          "name": "meta.include-named-argument"
-        },
-        {
-          "match": "([^}\\s]*)\\s*",
+          "match": "(?<=\\s)(&[a-zA-Z][a-zA-Z0-9\\#\\$\\-\\_\\%\\.]+)\\s*(=?)",
+          "comment": "non-string argument values after the &arg = ",
+          "name": "meta.include-named-argument",
           "captures": {
             "1": {
-              "name": "string.unquoted.include-argument.abl"
+              "name": "support.other.argument.abl",
+              "comment": "you can use variable names, field names, and reserved words as argument names."
+            },
+            "2": {
+              "name": "keyword.operator.source.abl"
             }
           }
+        },
+        {
+          "include": "#string"
         }
-      ],
-      "comment": "https://docs.progress.com/bundle/openedge-abl-reference-122/page/Include-file-reference.html"
+      ]
     },
     "argument-reference": {
       "comment": "https://docs.progress.com/bundle/openedge-abl-reference-122/page/Argument-reference.html",
       "match": "\\s*((\\{\\s*\\&[\\.\\w\\\/-]+\\})|(\\{\\s*\\d+\\})|(\\{\\s*\\*\\}))\\s*",
       "captures": {
         "1": {
-          "name": "storage.other.abl"
+            "name": "support.other.argument.abl"
         }
       }
     },

--- a/spec/include/abl-tmlanguage-issues#5.spec.js
+++ b/spec/include/abl-tmlanguage-issues#5.spec.js
@@ -6,17 +6,17 @@ describe('', () => {
     `{assigned "mExtVar"}      /* comment */`;
 
   let expectedTokens = [
-    { "startIndex": 0, "endIndex": 1, "scopes": ["source.abl", "meta.include.abl", "punctuation.section.abl"] },
-    { "startIndex": 1, "endIndex": 9, "scopes": ["source.abl", "meta.include.abl", "string.unquoted.include-argument.abl"] },
-    { "startIndex": 9, "endIndex": 10, "scopes": ["source.abl", "meta.include.abl"] },
-    { "startIndex": 10, "endIndex": 11, "scopes": ["source.abl", "meta.include.abl", "string.double.complex.abl", "punctuation.definition.string.begin.abl"] },
-    { "startIndex": 11, "endIndex": 18, "scopes": ["source.abl", "meta.include.abl", "string.double.complex.abl"] },
-    { "startIndex": 18, "endIndex": 19, "scopes": ["source.abl", "meta.include.abl", "string.double.complex.abl", "punctuation.definition.string.end.abl"] },
-    { "startIndex": 19, "endIndex": 20, "scopes": ["source.abl", "meta.include.abl", "punctuation.section.abl"] },
-    { "startIndex": 20, "endIndex": 26, "scopes": ["source.abl"] },
-    { "startIndex": 26, "endIndex": 28, "scopes": ["source.abl", "comment.block.source.abl"] },
-    { "startIndex": 28, "endIndex": 37, "scopes": ["source.abl", "comment.block.source.abl", "comment"] },
-    { "startIndex": 37, "endIndex": 39, "scopes": ["source.abl", "comment.block.source.abl"] }
+    { "startIndex": 0, "endIndex": 1, "scopes": ["source.abl", "meta.include.abl", "punctuation.section.abl"] },  // '{'
+    { "startIndex": 1, "endIndex": 9, "scopes": ["source.abl", "meta.include.abl", "meta.other.include.abl"] },  // 'assigned'
+    { "startIndex": 9, "endIndex": 10, "scopes": ["source.abl", "meta.include.abl"] },  // ' '
+    { "startIndex": 10, "endIndex": 11, "scopes": ["source.abl", "meta.include.abl", "string.double.complex.abl", "punctuation.definition.string.begin.abl"] },  // '"'
+    { "startIndex": 11, "endIndex": 18, "scopes": ["source.abl", "meta.include.abl", "string.double.complex.abl"] },  // 'mExtVar'
+    { "startIndex": 18, "endIndex": 19, "scopes": ["source.abl", "meta.include.abl", "string.double.complex.abl", "punctuation.definition.string.end.abl"] },  // '"'
+    { "startIndex": 19, "endIndex": 20, "scopes": ["source.abl", "meta.include.abl", "punctuation.section.abl"] },  // '}'
+    { "startIndex": 20, "endIndex": 26, "scopes": ["source.abl", "meta.include.abl"] },  // '      '
+    { "startIndex": 26, "endIndex": 28, "scopes": ["source.abl", "comment.block.source.abl"] },  // '/*'
+    { "startIndex": 28, "endIndex": 37, "scopes": ["source.abl", "comment.block.source.abl", "comment"] },  // ' comment '
+    { "startIndex": 37, "endIndex": 39, "scopes": ["source.abl", "comment.block.source.abl"] }  // '*/'
   ];
 
   shared.itShouldMatchExpectedScopes(statement, expectedTokens);
@@ -26,32 +26,15 @@ describe('', () => {
     `{assigned &ExtVar}       /* comment */`;
 
   let expectedTokens = [
-    { "startIndex": 0, "endIndex": 1, "scopes": ["source.abl", "meta.include.abl", "punctuation.section.abl"] },
-    { "startIndex": 1, "endIndex": 9, "scopes": ["source.abl", "meta.include.abl", "string.unquoted.include-argument.abl"] },
-    { "startIndex": 9, "endIndex": 10, "scopes": ["source.abl", "meta.include.abl"] },
-    { "startIndex": 10, "endIndex": 17, "scopes": ["source.abl", "meta.include.abl", "string.unquoted.include-argument.abl"] },
-    { "startIndex": 17, "endIndex": 18, "scopes": ["source.abl", "meta.include.abl", "punctuation.section.abl"] },
-    { "startIndex": 18, "endIndex": 25, "scopes": ["source.abl"] },
-    { "startIndex": 25, "endIndex": 27, "scopes": ["source.abl", "comment.block.source.abl"] },
-    { "startIndex": 27, "endIndex": 36, "scopes": ["source.abl", "comment.block.source.abl", "comment"] },
-    { "startIndex": 36, "endIndex": 38, "scopes": ["source.abl", "comment.block.source.abl"] }
-  ];
-  shared.itShouldMatchExpectedScopes(statement, expectedTokens);
-})
-describe('', () => {
-  let statement =
-    `{assigned mExtVar}       /* comment */`;
-
-  let expectedTokens = [
-    { "startIndex": 0, "endIndex": 1, "scopes": ["source.abl", "meta.include.abl", "punctuation.section.abl"] },
-    { "startIndex": 1, "endIndex": 9, "scopes": ["source.abl", "meta.include.abl", "string.unquoted.include-argument.abl"] },
-    { "startIndex": 9, "endIndex": 10, "scopes": ["source.abl", "meta.include.abl"] },
-    { "startIndex": 10, "endIndex": 17, "scopes": ["source.abl", "meta.include.abl", "string.unquoted.include-argument.abl"] },
-    { "startIndex": 17, "endIndex": 18, "scopes": ["source.abl", "meta.include.abl", "punctuation.section.abl"] },
-    { "startIndex": 18, "endIndex": 25, "scopes": ["source.abl"] },
-    { "startIndex": 25, "endIndex": 27, "scopes": ["source.abl", "comment.block.source.abl"] },
-    { "startIndex": 27, "endIndex": 36, "scopes": ["source.abl", "comment.block.source.abl", "comment"] },
-    { "startIndex": 36, "endIndex": 38, "scopes": ["source.abl", "comment.block.source.abl"] }
+    { "startIndex": 0, "endIndex": 1, "scopes": ["source.abl", "meta.include.abl", "punctuation.section.abl"] },  // '{'
+    { "startIndex": 1, "endIndex": 9, "scopes": ["source.abl", "meta.include.abl", "meta.other.include.abl"] },  // 'assigned'
+    { "startIndex": 9, "endIndex": 10, "scopes": ["source.abl", "meta.include.abl"] },  // ' '
+    { "startIndex": 10, "endIndex": 17, "scopes": ["source.abl", "meta.include.abl", "meta.include.argument.abl", "support.other.argument.abl"] },  // '&ExtVar'
+    { "startIndex": 17, "endIndex": 18, "scopes": ["source.abl", "meta.include.abl", "punctuation.section.abl"] },  // '}'
+    { "startIndex": 18, "endIndex": 25, "scopes": ["source.abl", "meta.include.abl"] },  // '       '
+    { "startIndex": 25, "endIndex": 27, "scopes": ["source.abl", "comment.block.source.abl"] },  // '/*'
+    { "startIndex": 27, "endIndex": 36, "scopes": ["source.abl", "comment.block.source.abl", "comment"] },  // ' comment '
+    { "startIndex": 36, "endIndex": 38, "scopes": ["source.abl", "comment.block.source.abl"] }  // '*/'
   ];
   shared.itShouldMatchExpectedScopes(statement, expectedTokens);
 })

--- a/spec/include/vscode-abl-issue#45.spec.js
+++ b/spec/include/vscode-abl-issue#45.spec.js
@@ -8,7 +8,7 @@ describe('', () => {
   let expectedTokens = [
     { "startIndex": 0, "endIndex": 1, "scopes": ["source.abl", "meta.include.abl", "punctuation.section.abl"] },  // '{'
     { "startIndex": 1, "endIndex": 2, "scopes": ["source.abl", "meta.include.abl"] },  // ' '
-    { "startIndex": 2, "endIndex": 8, "scopes": ["source.abl", "meta.include.abl", "string.unquoted.include-argument.abl"] },  // 'test.i'
+    { "startIndex": 2, "endIndex": 8, "scopes": ["source.abl", "meta.include.abl", "meta.other.include.abl"] },  // 'test.i'
     { "startIndex": 8, "endIndex": 9, "scopes": ["source.abl", "meta.include.abl"] },  // ' '
     { "startIndex": 9, "endIndex": 10, "scopes": ["source.abl", "meta.include.abl", "string.double.complex.abl", "punctuation.definition.string.begin.abl"] },  // '"'
     { "startIndex": 10, "endIndex": 17, "scopes": ["source.abl", "meta.include.abl", "string.double.complex.abl"] },  // '{&Test}'

--- a/spec/include/vscode-abl-issue#77.spec.js
+++ b/spec/include/vscode-abl-issue#77.spec.js
@@ -1,0 +1,129 @@
+const { assert, expect } = require('chai');
+const shared = require('../shared.js');
+
+describe('', () => {
+  let statement =
+    `{rec/zetin.ooi &where="zetin.act"}`;
+
+  let expectedTokens = [
+    { "startIndex": 0, "endIndex": 1, "scopes": ["source.abl", "meta.include.abl", "punctuation.section.abl"] },  // '{'
+    { "startIndex": 1, "endIndex": 14, "scopes": ["source.abl", "meta.include.abl", "meta.other.include.abl"] },  // 'rec/zetin.ooi'
+    { "startIndex": 14, "endIndex": 15, "scopes": ["source.abl", "meta.include.abl"] },  // ' '
+    { "startIndex": 15, "endIndex": 21, "scopes": ["source.abl", "meta.include.abl", "meta.include.argument.abl", "support.other.argument.abl"] },  // '&where'
+    { "startIndex": 21, "endIndex": 22, "scopes": ["source.abl", "meta.include.abl", "meta.include.argument.abl", "keyword.operator.source.abl"] },  // '='
+    { "startIndex": 22, "endIndex": 23, "scopes": ["source.abl", "meta.include.abl", "string.double.complex.abl", "punctuation.definition.string.begin.abl"] },  // '"'
+    { "startIndex": 23, "endIndex": 32, "scopes": ["source.abl", "meta.include.abl", "string.double.complex.abl"] },  // 'zetin.act'
+    { "startIndex": 32, "endIndex": 33, "scopes": ["source.abl", "meta.include.abl", "string.double.complex.abl", "punctuation.definition.string.end.abl"] },  // '"'
+    { "startIndex": 33, "endIndex": 34, "scopes": ["source.abl", "meta.include.abl", "punctuation.section.abl"] }  // '}'
+  ];
+  shared.itShouldMatchExpectedScopes(statement, expectedTokens);
+})
+
+describe('', () => {
+  let statement =
+    `{rec/zetin.ooi
+    &where="zetin.act"
+}`;
+
+  let expectedTokens = [
+    [
+      { "startIndex": 0, "endIndex": 1, "scopes": ["source.abl", "meta.include.abl", "punctuation.section.abl"] },  // '{'
+      { "startIndex": 1, "endIndex": 14, "scopes": ["source.abl", "meta.include.abl", "meta.other.include.abl"] }  // 'rec/zetin.ooi'
+    ],
+    [
+      { "startIndex": 0, "endIndex": 4, "scopes": ["source.abl", "meta.include.abl"] },  // '    '
+      { "startIndex": 4, "endIndex": 10, "scopes": ["source.abl", "meta.include.abl", "meta.include.argument.abl", "support.other.argument.abl"] },  // '&where'
+      { "startIndex": 10, "endIndex": 11, "scopes": ["source.abl", "meta.include.abl", "meta.include.argument.abl", "keyword.operator.source.abl"] },  // '='
+      { "startIndex": 11, "endIndex": 12, "scopes": ["source.abl", "meta.include.abl", "string.double.complex.abl", "punctuation.definition.string.begin.abl"] },  // '"'
+      { "startIndex": 12, "endIndex": 21, "scopes": ["source.abl", "meta.include.abl", "string.double.complex.abl"] },  // 'zetin.act'
+      { "startIndex": 21, "endIndex": 22, "scopes": ["source.abl", "meta.include.abl", "string.double.complex.abl", "punctuation.definition.string.end.abl"] }  // '"'
+    ],
+    [
+      { "startIndex": 0, "endIndex": 1, "scopes": ["source.abl", "meta.include.abl", "punctuation.section.abl"] }  // '}'
+    ]
+  ];
+  shared.itShouldMatchExpectedScopes(statement, expectedTokens);
+})
+
+describe('', () => {
+  let statement =
+    `{rec/zetin.ooi &where="zetin.act
+    AND CAN-FIND(FIRST ztihu WHERE ztihu.zetin_iden = zetin.zetin_iden)"}
+`;
+
+  let expectedTokens = [
+    [
+      { "startIndex": 0, "endIndex": 1, "scopes": ["source.abl", "meta.include.abl", "punctuation.section.abl"] },  // '{'
+      { "startIndex": 1, "endIndex": 14, "scopes": ["source.abl", "meta.include.abl", "meta.other.include.abl"] },  // 'rec/zetin.ooi'
+      { "startIndex": 14, "endIndex": 15, "scopes": ["source.abl", "meta.include.abl"] },  // ' '
+      { "startIndex": 15, "endIndex": 21, "scopes": ["source.abl", "meta.include.abl", "meta.include.argument.abl", "support.other.argument.abl"] },  // '&where'
+      { "startIndex": 21, "endIndex": 22, "scopes": ["source.abl", "meta.include.abl", "meta.include.argument.abl", "keyword.operator.source.abl"] },  // '='
+      { "startIndex": 22, "endIndex": 23, "scopes": ["source.abl", "meta.include.abl", "string.double.complex.abl", "punctuation.definition.string.begin.abl"] },  // '"'
+      { "startIndex": 23, "endIndex": 33, "scopes": ["source.abl", "meta.include.abl", "string.double.complex.abl"] }  // 'zetin.act'
+    ],
+    [
+      { "startIndex": 0, "endIndex": 71, "scopes": ["source.abl", "meta.include.abl", "string.double.complex.abl"] },  // '    AND CAN-FIND(FIRST ztihu WHERE ztihu.zetin_iden = zetin.zetin_iden)'
+      { "startIndex": 71, "endIndex": 72, "scopes": ["source.abl", "meta.include.abl", "string.double.complex.abl", "punctuation.definition.string.end.abl"] },  // '"'
+      { "startIndex": 72, "endIndex": 73, "scopes": ["source.abl", "meta.include.abl", "punctuation.section.abl"] }  // '}'
+    ],
+    [
+      { "startIndex": 0, "endIndex": 1, "scopes": ["source.abl"] }  // ''
+    ]
+  ];
+  shared.itShouldMatchExpectedScopes(statement, expectedTokens);
+})
+
+describe('', () => {
+  let statement = `{rec/zetin.ooi &where="zetin.act" &MyArg &Thrid=43}`;
+
+  let expectedTokens = [
+    { "startIndex": 0, "endIndex": 1, "scopes": ["source.abl", "meta.include.abl", "punctuation.section.abl"] },  // '{'
+    { "startIndex": 1, "endIndex": 14, "scopes": ["source.abl", "meta.include.abl", "meta.other.include.abl"] },  // 'rec/zetin.ooi'
+    { "startIndex": 14, "endIndex": 15, "scopes": ["source.abl", "meta.include.abl"] },  // ' '
+    { "startIndex": 15, "endIndex": 21, "scopes": ["source.abl", "meta.include.abl", "meta.include.argument.abl", "support.other.argument.abl"] },  // '&where'
+    { "startIndex": 21, "endIndex": 22, "scopes": ["source.abl", "meta.include.abl", "meta.include.argument.abl", "keyword.operator.source.abl"] },  // '='
+    { "startIndex": 22, "endIndex": 23, "scopes": ["source.abl", "meta.include.abl", "string.double.complex.abl", "punctuation.definition.string.begin.abl"] },  // '"'
+    { "startIndex": 23, "endIndex": 32, "scopes": ["source.abl", "meta.include.abl", "string.double.complex.abl"] },  // 'zetin.act'
+    { "startIndex": 32, "endIndex": 33, "scopes": ["source.abl", "meta.include.abl", "string.double.complex.abl", "punctuation.definition.string.end.abl"] },  // '"'
+    { "startIndex": 33, "endIndex": 34, "scopes": ["source.abl", "meta.include.abl"] },  // ' '
+    { "startIndex": 34, "endIndex": 40, "scopes": ["source.abl", "meta.include.abl", "meta.include.argument.abl", "support.other.argument.abl"] },  // '&MyArg'
+    { "startIndex": 40, "endIndex": 41, "scopes": ["source.abl", "meta.include.abl", "meta.include.argument.abl"] },  // ' '
+    { "startIndex": 41, "endIndex": 47, "scopes": ["source.abl", "meta.include.abl", "meta.include.argument.abl", "support.other.argument.abl"] },  // '&Thrid'
+    { "startIndex": 47, "endIndex": 48, "scopes": ["source.abl", "meta.include.abl", "meta.include.argument.abl", "keyword.operator.source.abl"] },  // '='
+    { "startIndex": 48, "endIndex": 50, "scopes": ["source.abl", "meta.include.abl"] },  // '43'
+    { "startIndex": 50, "endIndex": 51, "scopes": ["source.abl", "meta.include.abl", "punctuation.section.abl"] }  // '}'
+  ];
+  shared.itShouldMatchExpectedScopes(statement, expectedTokens);
+})
+
+describe('', () => {
+  let statement = `{rec/zetin.ooi
+  &where="zetin.act"
+  &MyArg &Thrid=43}`;
+
+  let expectedTokens = [
+    [
+      { "startIndex": 0, "endIndex": 1, "scopes": ["source.abl", "meta.include.abl", "punctuation.section.abl"] },  // '{'
+      { "startIndex": 1, "endIndex": 14, "scopes": ["source.abl", "meta.include.abl", "meta.other.include.abl"] }  // 'rec/zetin.ooi'
+    ],
+    [
+      { "startIndex": 0, "endIndex": 2, "scopes": ["source.abl", "meta.include.abl"] },  // '  '
+      { "startIndex": 2, "endIndex": 8, "scopes": ["source.abl", "meta.include.abl", "meta.include.argument.abl", "support.other.argument.abl"] },  // '&where'
+      { "startIndex": 8, "endIndex": 9, "scopes": ["source.abl", "meta.include.abl", "meta.include.argument.abl", "keyword.operator.source.abl"] },  // '='
+      { "startIndex": 9, "endIndex": 10, "scopes": ["source.abl", "meta.include.abl", "string.double.complex.abl", "punctuation.definition.string.begin.abl"] },  // '"'
+      { "startIndex": 10, "endIndex": 19, "scopes": ["source.abl", "meta.include.abl", "string.double.complex.abl"] },  // 'zetin.act'
+      { "startIndex": 19, "endIndex": 20, "scopes": ["source.abl", "meta.include.abl", "string.double.complex.abl", "punctuation.definition.string.end.abl"] }  // '"'
+    ],
+    [
+      { "startIndex": 0, "endIndex": 2, "scopes": ["source.abl", "meta.include.abl"] },  // '  '
+      { "startIndex": 2, "endIndex": 8, "scopes": ["source.abl", "meta.include.abl", "meta.include.argument.abl", "support.other.argument.abl"] },  // '&MyArg'
+      { "startIndex": 8, "endIndex": 9, "scopes": ["source.abl", "meta.include.abl", "meta.include.argument.abl"] },  // ' '
+      { "startIndex": 9, "endIndex": 15, "scopes": ["source.abl", "meta.include.abl", "meta.include.argument.abl", "support.other.argument.abl"] },  // '&Thrid'
+      { "startIndex": 15, "endIndex": 16, "scopes": ["source.abl", "meta.include.abl", "meta.include.argument.abl", "keyword.operator.source.abl"] },  // '='
+      { "startIndex": 16, "endIndex": 18, "scopes": ["source.abl", "meta.include.abl"] },  // '43'
+      { "startIndex": 18, "endIndex": 19, "scopes": ["source.abl", "meta.include.abl", "punctuation.section.abl"] }  // '}'
+    ]
+  ];
+  shared.itShouldMatchExpectedScopes(statement, expectedTokens);
+})
+

--- a/spec/include/vscode-abl-issue#80.spec.js
+++ b/spec/include/vscode-abl-issue#80.spec.js
@@ -3,13 +3,13 @@ const shared = require('../shared.js');
 describe('', () => {
   let statement = `{ test.i {&Test} }`;
   let expectedTokens = [
-    { "startIndex": 0, "endIndex": 1, "scopes": ["source.abl", "meta.include.abl", "punctuation.section.abl"] },
-    { "startIndex": 1, "endIndex": 2, "scopes": ["source.abl", "meta.include.abl"] },
-    { "startIndex": 2, "endIndex": 8, "scopes": ["source.abl", "meta.include.abl", "string.unquoted.include-argument.abl"] },
-    { "startIndex": 8, "endIndex": 9, "scopes": ["source.abl", "meta.include.abl"] },
-    { "startIndex": 9, "endIndex": 16, "scopes": ["source.abl", "meta.include.abl", "keyword.other"] },
-    { "startIndex": 16, "endIndex": 17, "scopes": ["source.abl", "meta.include.abl"] },
-    { "startIndex": 17, "endIndex": 18, "scopes": ["source.abl", "meta.include.abl", "punctuation.section.abl"] }
+    { "startIndex": 0, "endIndex": 1, "scopes": ["source.abl", "meta.include.abl", "punctuation.section.abl"] },  // '{'
+    { "startIndex": 1, "endIndex": 2, "scopes": ["source.abl", "meta.include.abl"] },  // ' '
+    { "startIndex": 2, "endIndex": 8, "scopes": ["source.abl", "meta.include.abl", "meta.other.include.abl"] },  // 'test.i'
+    { "startIndex": 8, "endIndex": 9, "scopes": ["source.abl", "meta.include.abl"] },  // ' '
+    { "startIndex": 9, "endIndex": 16, "scopes": ["source.abl", "meta.include.abl", "support.other.argument.abl"] },  // '{&Test}'
+    { "startIndex": 16, "endIndex": 17, "scopes": ["source.abl", "meta.include.abl"] },  // ' '
+    { "startIndex": 17, "endIndex": 18, "scopes": ["source.abl", "meta.include.abl", "punctuation.section.abl"] }  // '}'
   ];
   shared.itShouldMatchExpectedScopes(statement, expectedTokens);
 })
@@ -17,17 +17,30 @@ describe('', () => {
 describe('', () => {
   let statement = `{ test.i &abc = ABC &def    = 'D E  F' &hij="H   I   J" }`;
   let expectedTokens = [
-    { "startIndex": 0, "endIndex": 1, "scopes": ["source.abl", "meta.include.abl", "punctuation.section.abl"] },
-    { "startIndex": 1, "endIndex": 2, "scopes": ["source.abl", "meta.include.abl"] },
-    { "startIndex": 2, "endIndex": 8, "scopes": ["source.abl", "meta.include.abl", "string.unquoted.include-argument.abl"] },
-    { "startIndex": 8, "endIndex": 9, "scopes": ["source.abl", "meta.include.abl"] },
-    { "startIndex": 9, "endIndex": 19, "scopes": ["source.abl", "meta.include.abl", "meta.include-named-argument"] },
-    { "startIndex": 19, "endIndex": 20, "scopes": ["source.abl", "meta.include.abl"] },
-    { "startIndex": 20, "endIndex": 38, "scopes": ["source.abl", "meta.include.abl", "meta.include-named-argument"] },
-    { "startIndex": 38, "endIndex": 39, "scopes": ["source.abl", "meta.include.abl"] },
-    { "startIndex": 39, "endIndex": 55, "scopes": ["source.abl", "meta.include.abl", "meta.include-named-argument"] },
-    { "startIndex": 55, "endIndex": 56, "scopes": ["source.abl", "meta.include.abl"] },
-    { "startIndex": 56, "endIndex": 57, "scopes": ["source.abl", "meta.include.abl", "punctuation.section.abl"] }
+    { "startIndex": 0, "endIndex": 1, "scopes": ["source.abl", "meta.include.abl", "punctuation.section.abl"] },  // '{'
+    { "startIndex": 1, "endIndex": 2, "scopes": ["source.abl", "meta.include.abl"] },  // ' '
+    { "startIndex": 2, "endIndex": 8, "scopes": ["source.abl", "meta.include.abl", "meta.other.include.abl"] },  // 'test.i'
+    { "startIndex": 8, "endIndex": 9, "scopes": ["source.abl", "meta.include.abl"] },  // ' '
+    { "startIndex": 9, "endIndex": 13, "scopes": ["source.abl", "meta.include.abl", "meta.include.argument.abl", "support.other.argument.abl"] },  // '&abc'
+    { "startIndex": 13, "endIndex": 14, "scopes": ["source.abl", "meta.include.abl", "meta.include.argument.abl"] },  // ' '
+    { "startIndex": 14, "endIndex": 15, "scopes": ["source.abl", "meta.include.abl", "meta.include.argument.abl", "keyword.operator.source.abl"] },  // '='
+    { "startIndex": 15, "endIndex": 20, "scopes": ["source.abl", "meta.include.abl"] },  // ' ABC '
+    { "startIndex": 20, "endIndex": 24, "scopes": ["source.abl", "meta.include.abl", "meta.include.argument.abl", "support.other.argument.abl"] },  // '&def'
+    { "startIndex": 24, "endIndex": 28, "scopes": ["source.abl", "meta.include.abl", "meta.include.argument.abl"] },  // '    '
+    { "startIndex": 28, "endIndex": 29, "scopes": ["source.abl", "meta.include.abl", "meta.include.argument.abl", "keyword.operator.source.abl"] },  // '='
+    { "startIndex": 29, "endIndex": 30, "scopes": ["source.abl", "meta.include.abl"] },  // ' '
+    { "startIndex": 30, "endIndex": 31, "scopes": ["source.abl", "meta.include.abl", "string.single.complex.abl", "punctuation.definition.string.begin.abl"] },  // '''
+    { "startIndex": 31, "endIndex": 37, "scopes": ["source.abl", "meta.include.abl", "string.single.complex.abl"] },  // 'D E  F'
+    { "startIndex": 37, "endIndex": 38, "scopes": ["source.abl", "meta.include.abl", "string.single.complex.abl", "punctuation.definition.string.end.abl"] },  // '''
+    { "startIndex": 38, "endIndex": 39, "scopes": ["source.abl", "meta.include.abl"] },  // ' '
+    { "startIndex": 39, "endIndex": 43, "scopes": ["source.abl", "meta.include.abl", "meta.include.argument.abl", "support.other.argument.abl"] },  // '&hij'
+    { "startIndex": 43, "endIndex": 44, "scopes": ["source.abl", "meta.include.abl", "meta.include.argument.abl", "keyword.operator.source.abl"] },  // '='
+    { "startIndex": 44, "endIndex": 45, "scopes": ["source.abl", "meta.include.abl", "string.double.complex.abl", "punctuation.definition.string.begin.abl"] },  // '"'
+    { "startIndex": 45, "endIndex": 54, "scopes": ["source.abl", "meta.include.abl", "string.double.complex.abl"] },  // 'H   I   J'
+    { "startIndex": 54, "endIndex": 55, "scopes": ["source.abl", "meta.include.abl", "string.double.complex.abl", "punctuation.definition.string.end.abl"] },  // '"'
+    { "startIndex": 55, "endIndex": 56, "scopes": ["source.abl", "meta.include.abl"] },  // ' '
+    { "startIndex": 56, "endIndex": 57, "scopes": ["source.abl", "meta.include.abl", "punctuation.section.abl"] }  // '}'
+
   ];
   shared.itShouldMatchExpectedScopes(statement, expectedTokens);
 })

--- a/spec/procedure-definition/vscode-abl-issue#62.spec.js
+++ b/spec/procedure-definition/vscode-abl-issue#62.spec.js
@@ -12,7 +12,7 @@ end procedure.`;
       { "startIndex": 0, "endIndex": 9, "scopes": ["source.abl", "meta.procedure.abl", "keyword.other.abl"] },  // 'PROCEDURE'
       { "startIndex": 9, "endIndex": 10, "scopes": ["source.abl", "meta.procedure.abl"] },  // ' '
       { "startIndex": 10, "endIndex": 22, "scopes": ["source.abl", "meta.procedure.abl", "entity.name.function.abl"] },  // 'EnumPrinters'
-      { "startIndex": 22, "endIndex": 26, "scopes": ["source.abl", "meta.procedure.abl", "storage.other.abl"] },  // '{&A}'
+      { "startIndex": 22, "endIndex": 26, "scopes": ["source.abl", "meta.procedure.abl", "support.other.argument.abl"] },  // '{&A}'
       { "startIndex": 26, "endIndex": 27, "scopes": ["source.abl", "meta.procedure.abl"] },  // ' '
       { "startIndex": 27, "endIndex": 35, "scopes": ["source.abl", "meta.procedure.abl", "keyword.other.abl"] },  // 'EXTERNAL'
       { "startIndex": 35, "endIndex": 36, "scopes": ["source.abl", "meta.procedure.abl"] },  // ' '


### PR DESCRIPTION

Additional tokens:
meta.other.include.abl = include file name
support.other.argument.abl = include arguments  (eg `&Arg` and `{1}` )


Addresses https://github.com/vscode-abl/vscode-abl/issues/77 