### PR TITLE
Use oniguruma-parser/optimizer to optimise the keyword regexes

### DIFF
--- a/abl.tmLanguage.json
+++ b/abl.tmLanguage.json
@@ -1854,7 +1854,6 @@
           "name": "constant.numeric.source.abl"
         }
       }
-
     },
     "define-query": {
       "begin": "(?i)\\b(query)\\s+([a-zA-Z_][a-zA-Z0-9_#$\\-%&]*)\\s*",
@@ -4000,7 +3999,7 @@
     },
     "keywords-A": {
       "comment": "The keyword must not have a trailing variable character (one of #$-_%&)",
-      "match": "(?i)\\b((accum(?:ulate|ulat|ula|ul|u)?)|(ambig(?:uous|uou|uo|u)?)|(array-m(?:essage|essag|essa|ess|es|e)?)|(asc(?:ending|endin|endi|end|en|e)?)|(avail(?:able|abl|ab|a)?)|(ave(?:rage|rag|ra|r)?)|abort|abstract|across|active-form|active-window|add|advise|aggregate|alert-box|all|allow-replication|alter|alternate-key|and|ansi-only|any|any-key|any-printable|anywhere|append|append-line|application|apply|as|as-cursor|ask-overwrite|assembly|assign|at|attach|attachment|attribute-type|audit-control|audit-policy|authorization|auto-endkey|auto-go|automatic|avg)\\b(?![#$\\-_%&])",
+      "match": "(?i)\\b(a(?:mbiguous?|mbiguo?|mbig|uto-go|vailable?|vailab?|vail|bstract|ccumulate?|ccumula?|ccumu?|cross|ctive-form|ctive-window|dd|dvise|ggregate|lert-box|ll|llow-replication|lter|lternate-key|nd|nsi-only|ny|nywhere|ppend|pplication|pply|rray-message?|rray-messa?|rray-mes?|rray-m|s|s-cursor|scending?|scendi?|scen?|sc|sk-overwrite|ssembly|ssign|t|ttach|ttachment|ttribute-type|udit-control|udit-policy|uthorization|uto-endkey|utomatic|verage?|vera?|ve|vg|ppend-line|bort|ny-key|ny-printable))\\b(?![#$\\-_%&])",
       "captures": {
         "1": {
           "name": "keyword.other.abl"
@@ -4009,7 +4008,7 @@
     },
     "keywords-B": {
       "comment": "The keyword must not have a trailing variable character (one of #$-_%&)",
-      "match": "(?i)\\b((backward(?:s)?)|(before-h(?:ide|id|i)?)|(bgc(?:olor|olo|ol|o)?)|(block-lev(?:el|e)?)|(border-b(?:ottom|otto|ott|ot|o)?)|(border-l(?:eft|ef|e)?)|(border-r(?:ight|igh|ig|i)?)|(border-t(?:op|o)?)|(buffer-comp(?:are|ar|a)?)|(button(?:s)?)|(button(?:s)?)|(by-variant-point(?:er|e)?)|back-tab|backspace|base-key|base64|batch|begins|bell|between|big-endian|binary|bind|bind-where|blob|block|both|bottom|bottom-column|break|break-line|browse|browse-column-data-types|browse-column-formats|browse-column-labels|browse-header|btos|buffer|buffer-copy|by|by-pointer|by-reference|by-value|byte)\\b(?![#$\\-_%&])",
+      "match": "(?i)\\b(b(?:gcolor?|gcol?|gc|ell|lock-level?|lock-lev|uffer-compare?|uffer-compa?|uffer-copy|rowse|uffer|uttons?|ackwards?|ase-key|ase64|atch|efore-hide?|efore-hi?|egins|etween|ig-endian|inary|ind|ind-where|lob|order-bottom?|order-bott?|order-bo?|order-left?|order-le?|order-right?|order-rig?|order-r|order-top?|order-t|oth|ottom|reak|rowse-column-data-types|rowse-column-formats|rowse-column-labels|rowse-header|tos|uttons?|y|y-pointer|y-reference|y-value|y-variant-pointer?|y-variant-point|yte|ackspace|reak-line|lock|ack-tab|ottom-column))\\b(?![#$\\-_%&])",
       "captures": {
         "1": {
           "name": "keyword.other.abl"
@@ -4018,7 +4017,7 @@
     },
     "keywords-C": {
       "comment": "The keyword must not have a trailing variable character (one of #$-_%&)",
-      "match": "(?i)\\b((center(?:ed|e)?)|(char(?:acter|acte|act|ac|a)?)|(colon-align(?:ed|e)?)|(column(?:s)?)|(column-lab(?:el|e)?)|(column-label-bgc(?:olor|olo|ol|o)?)|(column-label-fgc(?:olor|olo|ol|o)?)|(column-label-height-c(?:hars|har|ha|h)?)|(column-label-height-p(?:ixels|ixel|ixe|ix|i)?)|(compare(?:s)?)|(context-pop(?:up|u)?)|(control-cont(?:ainer|aine|ain|ai|a)?)|(control-fram(?:e)?)|(current-lang(?:uage|uag|ua|u)?)|(curs(?:or|o)?)|cache|cache-size|call|cancel-pick|case|catch|cdecl|chained|character_length|check|check-mem-stomp|choices|choose|class|clear|client-principal|clipboard|clob|close|codebase-locator|col|col-of|collate|colon|color|color-table|column-codepage|column-label-dcolor|column-label-font|column-of|com-self|combo-box|command|compile|compiler|component-handle|component-self|connect|constrained|constructor|container-event|contains|contents|context|context-help-id|control|convert|copy|copy-lob|count|create|create-on-add|create-test-file|ctos|current|current-value|current_date|cursor-down|cursor-left|cursor-right|cursor-up|cut)\\b(?![#$\\-_%&])",
+      "match": "(?i)\\b(c(?:entered?|enter|olumn-label?|olumn-lab|ontext-help-id|all|ase|atch|hoose|lass|lear|lose|olor|ompile|onnect|onstructor|opy-lob|reate|lient-principal|urrent-language?|urrent-langua?|urrent-lang|urrent-value|ursor?|urs|ache|ache-size|decl|hained|haracter?|haract?|hara?|haracter_length|heck|heck-mem-stomp|lipboard|lob|odebase-locator|ol|ol-of|ollate|olon|olon-aligned?|olon-align|olor-table|olumn-codepage|olumn-label-bgcolor?|olumn-label-bgcol?|olumn-label-bgc|olumn-label-dcolor|olumn-label-fgcolor?|olumn-label-fgcol?|olumn-label-fgc|olumn-label-font|olumn-label-height-chars?|olumn-label-height-cha?|olumn-label-height-c|olumn-label-height-pixels?|olumn-label-height-pixe?|olumn-label-height-pi?|olumn-of|olumns?|om-self|ombo-box|ommand|ompares?|ompiler|omponent-handle|omponent-self|onstrained|ontains|ontents|ontext|ontext-popup?|ontext-pop|ontrol|ontrol-container?|ontrol-contain?|ontrol-conta?|ontrol-frame?|onvert|ount|reate-on-add|reate-test-file|tos|urrent|urrent_date|ursor-up|ursor-down|ursor-left|ursor-right|hoices|ancel-pick|ut|opy|ontainer-event))\\b(?![#$\\-_%&])",
       "captures": {
         "1": {
           "name": "keyword.other.abl"
@@ -4027,7 +4026,7 @@
     },
     "keywords-D": {
       "comment": "The keyword must not have a trailing variable character (one of #$-_%&)",
-      "match": "(?i)\\b((data-b(?:ind|in|i)?)|(data-rel(?:ation|atio|ati|at|a)?)|(def(?:ine|in|i)?)|(default-ex(?:tension|tensio|tensi|tens|ten|te|t)?)|(desc(?:ending|endin|endi|end|en|e)?)|(dict(?:ionary|ionar|iona|ion|io|i)?)|(discon(?:nect|nec|ne|n)?)|(disp(?:lay|la|l)?)|data-refresh-line|data-refresh-page|data-source|database|dataset|dataset-handle|dcolor|dde|dde-notify|debug-list|debug-set-tenant|debugger|declare|default|default-action|default-pop-up|default-untranslatable|default-window|defer-lob-fetch|define-user-event-manager|del|delegate|delete|delete-character|delete-column|delete-end-line|delete-field|delete-word|delimiter|deselect|deselect-extend|deselection|deselection-extend|destructor|detach|dialog-box|dialog-help|dir|disable|disabled|dismiss-menu|distinct|dll-call-type|do|dos|dos-end|dotnet-clr-loaded|double|down|drop|drop-down|drop-down-list|drop-file-notify|drop-target|dslog-manager|dump|dynamic-current-value|dynamic-new|dynamic-property)\\b(?![#$\\-_%&])",
+      "match": "(?i)\\b(d(?:color|efault|elete|elimiter|rop-target|atabase|ataset|ata-source|de|efine?|efi?|estructor|ictionary?|ictiona?|ictio?|ict|isable|isconnect?|isconne?|iscon|isplay?|ispl?|os??|own|ynamic-current-value|ynamic-new|ynamic-property|ata-bind?|ata-bi?|ata-relation?|ata-relati?|ata-rela?|ataset-handle|ebug-list|ebug-set-tenant|ebugger|eclare|efault-extension?|efault-extensi?|efault-exten?|efault-ext?|efault-untranslatable|efault-window|efer-lob-fetch|efine-user-event-manager|elegate|escending?|escendi?|escen?|esc|etach|ialog-box|ialog-help|ir|isabled|istinct|ll-call-type|otnet-clr-loaded|ouble|rop|rop-down|rop-down-list|slog-manager|ump|elete-character|el|os-end|elete-field|elete-column|eselection|eselect|eselection-extend|eselect-extend|ismiss-menu|efault-action|elete-word|elete-end-line|efault-pop-up|de-notify|ata-refresh-line|ata-refresh-page|rop-file-notify))\\b(?![#$\\-_%&])",
       "captures": {
         "1": {
           "name": "keyword.other.abl"
@@ -4036,7 +4035,7 @@
     },
     "keywords-E": {
       "comment": "The keyword must not have a trailing variable character (one of #$-_%&)",
-      "match": "(?i)\\b((error-stat(?:us|u)?)|(exclusive-l(?:ock|oc|o)?)|(exclusive-web(?:-user|-use|-us|-u|-)?)|each|echo|edge|editing|editor|editor-backtab|editor-tab|else|empty|empty-selection|enable|end|end-box-selection|end-error|end-key|end-move|end-resize|end-row-resize|end-search|endkey|enter-menubar|entry|enum|eq|error|escape|event|event-handler-context|events|except|exclusive|execute|exists|exit|expire|explicit|export|extended|extent|external|extract)\\b(?![#$\\-_%&])",
+      "match": "(?i)\\b(e(?:rror|xecute|num|vent|mpty|nable|nd|ntry|xport|xtent|vents|xternal|ach|cho|dge|diting|ditor|lse|nd-key|ndkey|q|rror-status?|rror-stat|scape|vent-handler-context|xcept|xclusive|xclusive-lock?|xclusive-lo?|xclusive-web-user?|xclusive-web-us?|xclusive-web-?|xists|xpire|xplicit|xtended|xtract|nd-error|nd-move|nd-resize|nd-box-selection|mpty-selection|nter-menubar|xit|ditor-tab|ditor-backtab|nd-search|nd-row-resize))\\b(?![#$\\-_%&])",
       "captures": {
         "1": {
           "name": "keyword.other.abl"
@@ -4045,7 +4044,7 @@
     },
     "keywords-F": {
       "comment": "The keyword must not have a trailing variable character (one of #$-_%&)",
-      "match": "(?i)\\b((fgc(?:olor|olo|ol|o)?)|(field(?:s)?)|(file-access-d(?:ate|at|a)?)|(file-access-t(?:ime|im|i)?)|(file-info(?:rmation|rmatio|rmati|rmat|rma|rm|r)?)|(form(?:at|a)?)|(form(?:at|a)?)|(forward(?:s)?)|(fram(?:e)?)|(frame-val(?:ue|u)?)|(from-c(?:hars|har|ha|h)?)|(from-cur(?:rent|ren|re|r)?)|(from-p(?:ixels|ixel|ixe|ix|i)?)|false|false-leaks|fetch|file|filename|fill-in|filters|final|finally|find|find-case-sensitive|find-global|find-next|find-next-occurrence|find-prev-occurrence|find-previous|find-select|find-wrap-around|finder|firehose-cursor|first|fix-codepage|fixed-only|flags|flat-button|float|focus|focus-in|font|font-table|for|force-file|foreign-key-hidden|from|fromnoreorder|full-height|function|function-call-type)\\b(?![#$\\-_%&])",
+      "match": "(?i)\\b(f(?:gcolor?|gcol?|gc|lat-button|ont|oreign-key-hidden|ormat?|orm|rame?|inally|ind|irst|ix-codepage|or|ormat?|orm|rame-value?|rame-val|unction|rom|alse|alse-leaks|etch|ields?|ile|ile-access-date?|ile-access-da?|ile-access-time?|ile-access-ti?|ile-information?|ile-informati?|ile-informa?|ile-infor?|ilename|ill-in|ilters|inal|ind-case-sensitive|ind-global|ind-next-occurrence|ind-prev-occurrence|ind-select|ind-wrap-around|inder|irehose-cursor|ixed-only|lags|loat|ocus|ont-table|orce-file|orwards?|rom-chars?|rom-cha?|rom-c|rom-current?|rom-curre?|rom-cur|rom-pixels?|rom-pixe?|rom-pi?|romnoreorder|ull-height|unction-call-type|ocus-in|ind-next|ind-previous))\\b(?![#$\\-_%&])",
       "captures": {
         "1": {
           "name": "keyword.other.abl"
@@ -4054,7 +4053,7 @@
     },
     "keywords-G": {
       "comment": "The keyword must not have a trailing variable character (one of #$-_%&)",
-      "match": "(?i)\\b((get-key-val(?:ue|u)?)|ge|generate-md5|get|get-attr-call-type|get-dir|get-file|get-text-height|get-text-width|getbyte|global|go|go-on|goto|grant|grant-archive|grayed|grid-set|grid-unit-height|grid-unit-width|group|gt)\\b(?![#$\\-_%&])",
+      "match": "(?i)\\b(g(?:et|et-key-value?|et-key-val|et-dir|et-file|e|enerate-md5|et-attr-call-type|et-text-height|et-text-width|etbyte|lob(?:al?)?|o-on|rant|rant-archive|rayed|rid-set|rid-unit-height|rid-unit-width|roup|[ot]|oto))\\b(?![#$\\-_%&])",
       "captures": {
         "1": {
           "name": "keyword.other.abl"
@@ -4063,7 +4062,7 @@
     },
     "keywords-H": {
       "comment": "The keyword must not have a trailing variable character (one of #$-_%&)",
-      "match": "(?i)\\b((help-con(?:text|tex|te|t)?)|(helpfile-n(?:ame|am|a)?)|having|header|height|help-topic|hidden|hide|hint|home|horiz-end|horiz-home|horiz-scroll-drag|host-byte-order)\\b(?![#$\\-_%&])",
+      "match": "(?i)\\b(h(?:idden|ide|aving|eader|eight|elp-context?|elp-conte?|elp-con|elp-topic|elpfile-name?|elpfile-na?|int|ost-byte-order|ome|oriz-scroll-drag|oriz-home|oriz-end))\\b(?![#$\\-_%&])",
       "captures": {
         "1": {
           "name": "keyword.other.abl"
@@ -4072,7 +4071,7 @@
     },
     "keywords-I": {
       "comment": "The keyword must not have a trailing variable character (one of #$-_%&)",
-      "match": "(?i)\\b((image-size-c(?:hars|har|ha|h)?)|(image-size-p(?:ixels|ixel|ixe|ix|i)?)|(info(?:rmation|rmatio|rmati|rmat|rma|rm|r)?)|(input-o(?:utput|utpu|utp|ut|u)?)|if|image|image-down|image-insensitive|image-size|image-up|implements|import|in|index-hint|indexed-reposition|indicator|inherit-color-mode|inherits|init|initial|initial-dir|initial-filter|initiate|inner|input|insert|insert-column|insert-field|insert-field-data|insert-field-label|insert-mode|interface|into|is|item|iteration-changed)\\b(?![#$\\-_%&])",
+      "match": "(?i)\\b(i(?:mage-down|mage-insensitive|mage-up|nitial|nitiate|mage|mport|nput|nput-output?|nput-outp?|nput-ou?|nsert|nterface|f|mage-size|mage-size-chars?|mage-size-cha?|mage-size-c|mage-size-pixels?|mage-size-pixe?|mage-size-pi?|mplements|n|ndex-hint|ndexed-reposition|ndicator|nformation?|nformati?|nforma?|nfor?|nherit-color-mode|nherits|nit|nitial-dir|nitial-filter|nner|nto|s|tem|nsert-mode|nsert-field|nsert-field-data|nsert-field-label|nsert-column|teration-changed))\\b(?![#$\\-_%&])",
       "captures": {
         "1": {
           "name": "keyword.other.abl"
@@ -4081,7 +4080,7 @@
     },
     "keywords-J": {
       "comment": "The keyword must not have a trailing variable character (one of #$-_%&)",
-      "match": "(?i)\\b(join|join-by-sqldb|join-on-select)\\b(?![#$\\-_%&])",
+      "match": "(?i)\\b(join(?:|-by-sqldb|-on-select))\\b(?![#$\\-_%&])",
       "captures": {
         "1": {
           "name": "keyword.other.abl"
@@ -4090,7 +4089,7 @@
     },
     "keywords-K": {
       "comment": "The keyword must not have a trailing variable character (one of #$-_%&)",
-      "match": "(?i)\\b((keep-frame-z(?:-order|-orde|-ord|-or|-o|-)?)|(key-func(?:tion|tio|ti|t)?)|keep-messages|keep-tab-order|key-code|key-label|keycache-join)\\b(?![#$\\-_%&])",
+      "match": "(?i)\\b(ke(?:ep-frame-z-order?|ep-frame-z-ord?|ep-frame-z-o?|ep-frame-z|ep-messages|ep-tab-order|y-code|y-function?|y-functi?|y-func|y-label|ycache-join))\\b(?![#$\\-_%&])",
       "captures": {
         "1": {
           "name": "keyword.other.abl"
@@ -4099,7 +4098,7 @@
     },
     "keywords-L": {
       "comment": "The keyword must not have a trailing variable character (one of #$-_%&)",
-      "match": "(?i)\\b((label-pfc(?:olor|olo|ol|o)?)|(last-even(?:t)?)|(left-align(?:ed|e)?)|(listi(?:ng|n)?)|(longch(?:ar|a)?)|label|landscape|last-key|le|leading|leak-detection|leave|left|left-end|length|like|like-sequential|line-down|line-left|line-right|line-up|little-endian|load|load-from|load-picture|load-result-into|lob-dir|locked|log-id|log-manager|long|lookahead|lower|lt)\\b(?![#$\\-_%&])",
+      "match": "(?i)\\b(l(?:abel|ocked|eave|ength|oad|oad-picture|abel-pfcolor?|abel-pfcol?|abel-pfc|andscape|ast-event?|ast-key|e|eading|eak-detection|eft|eft-aligned?|eft-align|ike|ike-sequential|isting?|isti|ittle-endian|oad-from|oad-result-into|ob-dir|og-id|og-manager|ong|ongchar?|ongch|ookahead|ower|t|eft-end|ine-up|ine-down|ine-right|ine-left))\\b(?![#$\\-_%&])",
       "captures": {
         "1": {
           "name": "keyword.other.abl"
@@ -4108,7 +4107,7 @@
     },
     "keywords-M": {
       "comment": "The keyword must not have a trailing variable character (one of #$-_%&)",
-      "match": "(?i)\\b((margin-height-c(?:hars|har|ha|h)?)|(margin-height-p(?:ixels|ixel|ixe|ix|i)?)|(margin-width-c(?:hars|har|ha|h)?)|(margin-width-p(?:ixels|ixel|ixe|ix|i)?)|(min-schema-marshal(?:l)?)|(mouse-p(?:ointer|ointe|oint|oin|oi|o)?)|machine-class|main-menu|map|margin-extra|margin-height|margin-width|matches|max|max-button|max-height|max-rows|max-size|max-width|maximize|md5-value|memptr|menu|menu-drop|menu-item|menubar|message|message-area|message-area-msg|message-line|method|min-height|min-size|min-width|mod|modulo|mouse|move|mpe|multiple-key|must-exist)\\b(?![#$\\-_%&])",
+      "match": "(?i)\\b(m(?:ax-button|essage-area|ouse-pointer?|ouse-point?|ouse-poi?|ouse-p|enu|essage|ethod|achine-class|ap|argin-extra|argin-height|argin-height-chars?|argin-height-cha?|argin-height-c|argin-height-pixels?|argin-height-pixe?|argin-height-pi?|argin-width|argin-width-chars?|argin-width-cha?|argin-width-c|argin-width-pixels?|argin-width-pixe?|argin-width-pi?|atches|ax|ax-height|ax-rows|ax-size|ax-width|aximize|d5-value|emptr|enu-item|enubar|essage-area-msg|essage-line|in-height|in-schema-marshall?|in-size|in-width|od|odulo|ouse|pe|ultiple-key|ust-exist|ove|ain-menu|enu-drop))\\b(?![#$\\-_%&])",
       "captures": {
         "1": {
           "name": "keyword.other.abl"
@@ -4117,7 +4116,7 @@
     },
     "keywords-N": {
       "comment": "The keyword must not have a trailing variable character (one of #$-_%&)",
-      "match": "(?i)\\b((no-array-m(?:essage|essag|essa|ess|es|e)?)|(no-attr-l(?:ist|is|i)?)|(no-attr-s(?:pace|pac|pa|p)?)|(no-auto-tri(?:m)?)|(no-column-sc(?:rolling|rollin|rolli|roll|rol|ro|r)?)|(no-convert-3d(?:-colors|-color|-colo|-col|-co|-c|-)?)|(no-f(?:ill|il|i)?)|(no-inherit-bgc(?:olor|olo|ol|o)?)|(no-inherit-fgc(?:olor|olo|ol|o)?)|(no-label(?:s)?)|(no-mes(?:sage|sag|sa|s)?)|(no-prefe(?:tch|tc|t)?)|(no-query-o(?:rder-added|rder-adde|rder-add|rder-ad|rder-a|rder-|rder|rde|rd|r)?)|(no-query-u(?:nique-added|nique-adde|nique-add|nique-ad|nique-a|nique-|nique|niqu|niq|ni|n)?)|(no-return-val(?:ue|u)?)|(no-schema-marshal(?:l)?)|(no-scrollbar-v(?:ertical|ertica|ertic|erti|ert|er|e)?)|(no-tab(?:-stop|-sto|-st|-s|-)?)|(no-und(?:erline|erlin|erli|erl|er|e)?)|namespace-prefix|namespace-uri|native|ne|nested|new|new-instance|new-line|next|next-error|next-frame|next-prompt|next-word|no|no-apply|no-assign|no-attr|no-auto-validate|no-bind-where|no-box|no-console|no-convert|no-debug|no-drag|no-echo|no-error|no-firehose-cursor|no-focus|no-help|no-hide|no-index-hint|no-join-by-sqldb|no-keycache-join|no-lobs|no-lock|no-lookahead|no-map|no-pause|no-row-markers|no-scrolling|no-separate-connection|no-separators|no-undo|no-wait|no-word-wrap|node-type|non-serializable|none|not-active|null|num-copies|num-selected|numeric)\\b(?![#$\\-_%&])",
+      "match": "(?i)\\b(n(?:amespace-prefix|amespace-uri|ested|o-focus|ew|ext|ext-prompt|ative|e|ew-instance|o|o-apply|o-array-message?|o-array-messa?|o-array-mes?|o-array-m|o-assign|o-attr|o-attr-list?|o-attr-li?|o-attr-space?|o-attr-spa?|o-attr-s|o-auto-trim?|o-auto-validate|o-bind-where|o-box|o-column-scrolling?|o-column-scrolli?|o-column-scrol?|o-column-scr?|o-console|o-convert|o-convert-3d-colors?|o-convert-3d-colo?|o-convert-3d-co?|o-convert-3d-?|o-debug|o-drag|o-echo|o-error|o-fill?|o-fi?|o-firehose-cursor|o-help|o-hide|o-index-hint|o-inherit-bgcolor?|o-inherit-bgcol?|o-inherit-bgc|o-inherit-fgcolor?|o-inherit-fgcol?|o-inherit-fgc|o-join-by-sqldb|o-keycache-join|o-labels?|o-lobs|o-lock|o-lookahead|o-map|o-message?|o-messa?|o-mes|o-pause|o-prefetch?|o-prefet?|o-query-order-added?|o-query-order-add?|o-query-order-a?|o-query-order?|o-query-ord?|o-query-o|o-query-unique-added?|o-query-unique-add?|o-query-unique-a?|o-query-unique?|o-query-uniq?|o-query-un?|o-return-value?|o-return-val|o-row-markers|o-schema-marshall?|o-scrollbar-vertical?|o-scrollbar-vertic?|o-scrollbar-vert?|o-scrollbar-ve?|o-scrolling|o-separate-connection|o-separators|o-tab-stop?|o-tab-st?|o-tab-?|o-underline?|o-underli?|o-under?|o-undo??|o-wait|o-word-wrap|ode-type|on-serializable|one|ot-active|ull|um-copies|um-selected|umeric|ew-line|ext-frame|ext-word|ext-error))\\b(?![#$\\-_%&])",
       "captures": {
         "1": {
           "name": "keyword.other.abl"
@@ -4126,7 +4125,7 @@
     },
     "keywords-O": {
       "comment": "The keyword must not have a trailing variable character (one of #$-_%&)",
-      "match": "(?i)\\b((ole-invoke-loca(?:le|l)?)|(ole-names-loca(?:le|l)?)|object|octet_length|of|off|off-end|off-home|ok|ok-cancel|old|on|open|open-line-above|option|options-file|or|ordered-join|orientation|os-append|os-command|os-copy|os-create-dir|os-delete|os-dir|os-rename|os2|os400|otherwise|out-of-data|outer|outer-join|output|overlay|override)\\b(?![#$\\-_%&])",
+      "match": "(?i)\\b(o(?:n|bject|pen|s-append|s-command|s-copy|s-create-dir|s-delete|s-rename|utput|verlay|ctet_length|ff??|k|k-cancel|ld|le-invoke-locale?|le-invoke-loca|le-names-locale?|le-names-loca|ption|ptions-file|r|rdered-join|rientation|s-dir|s2|s400|therwise|uter|uter-join|verride|pen-line-above|ff-home|ff-end|ut-of-data))\\b(?![#$\\-_%&])",
       "captures": {
         "1": {
           "name": "keyword.other.abl"
@@ -4135,7 +4134,7 @@
     },
     "keywords-P": {
       "comment": "The keyword must not have a trailing variable character (one of #$-_%&)",
-      "match": "(?i)\\b((page-wid(?:th|t)?)|(param(?:eter|ete|et|e)?)|(perf(?:ormance|ormanc|orman|orma|orm|or|o)?)|(pfc(?:olor|olo|ol|o)?)|(preproc(?:ess|es|e)?)|(presel(?:ect|ec|e)?)|(proce(?:dure|dur|du|d)?)|(prompt-f(?:or|o)?)|(put-key-val(?:ue|u)?)|package-private|package-protected|page|page-down|page-left|page-right|page-right-text|page-up|paged|parent-id-field|parent-window-close|partial-key|pascal|paste|pause|pick|pick-area|pick-both|pixels|portrait|precision|prev|prev-frame|prev-word|printer|printer-setup|private|privileges|procedure-call-type|procedure-complete|process|profile-file|profiler|prompt|promsgs|propath|property|protected|public|publish|put|put-bits|put-byte|put-bytes|put-double|put-float|put-int64|put-long|put-short|put-string|put-unsigned-long|put-unsigned-short|putbyte)\\b(?![#$\\-_%&])",
+      "match": "(?i)\\b(p(?:fcolor?|fcol?|fc|arameter?|aramet?|aram|roperty|rocedure?|rocedu?|roce|age|ause|rocess|rompt-for?|rompt-f|romsgs|ropath|ublish|ut|ut-bits|ut-bytes??|ut-double|ut-float|ut-int64|ut-key-value?|ut-key-val|ut-long|ut-short|ut-string|ut-unsigned-long|ut-unsigned-short|rinter-setup|ackage-private|ackage-protected|age-width?|age-wid|aged|arent-id-field|artial-key|ascal|erformance?|erforman?|erform?|erfo?|ixels|ortrait|recision|reprocess?|reproce?|reselect?|resele?|rev|rinter|rivate|rivileges|rocedure-call-type|rofile-file|rofiler|rompt|rotected|ublic|utbyte|age-up|age-down|ick|ick-both|ick-area|aste|rev-word|rev-frame|age-right|age-left|age-right-text|arent-window-close|rocedure-complete))\\b(?![#$\\-_%&])",
       "captures": {
         "1": {
           "name": "keyword.other.abl"
@@ -4144,7 +4143,7 @@
     },
     "keywords-Q": {
       "comment": "The keyword must not have a trailing variable character (one of #$-_%&)",
-      "match": "(?i)\\b(query|query-tuning|question|quit)\\b(?![#$\\-_%&])",
+      "match": "(?i)\\b(qu(?:ery|it|ery-tuning|estion))\\b(?![#$\\-_%&])",
       "captures": {
         "1": {
           "name": "keyword.other.abl"
@@ -4153,7 +4152,7 @@
     },
     "keywords-R": {
       "comment": "The keyword must not have a trailing variable character (one of #$-_%&)",
-      "match": "(?i)\\b((rcode-info(?:rmation|rmatio|rmati|rmat|rma|rm|r)?)|(rect(?:angle|angl|ang|an|a)?)|(reposition-back(?:wards|ward|war|wa|w)?)|(reposition-forw(?:ards|ard|ar|a)?)|(reposition-parent-rel(?:ation|atio|ati|at|a)?)|(return-to-start-di(?:r)?)|(return-val(?:ue|u)?)|(right-align(?:ed|e)?)|(run-proc(?:edure|edur|edu|ed|e)?)|radio-set|raw|raw-transfer|read-available|read-exact-num|read-response|readkey|real|recall|recursive|reference-only|reinstate|release|repeat|replication-create|replication-delete|replication-write|reports|reposition|request|resize|result|resume-display|retain|retry-cancel|return|returns|reverse-from|revert|revoke|right|right-end|routine-level|row|row-created|row-deleted|row-display|row-entry|row-height|row-leave|row-modified|row-of|row-unmodified|rule|rule-row|rule-y|run)\\b(?![#$\\-_%&])",
+      "match": "(?i)\\b(r(?:ecursive|esize|eturn-value?|eturn-val|ow|equest|ectangle?|ectang?|ecta?|aw|aw-transfer|eadkey|elease|epeat|eposition|eturn|outine-level|un|adio-set|code-information?|code-informati?|code-informa?|code-infor?|ead-available|ead-exact-num|eal|eference-only|einstate|eplication-create|eplication-delete|eplication-write|eposition-backwards?|eposition-backwar?|eposition-backw?|eposition-forwards?|eposition-forwar?|eposition-forw|eposition-parent-relation?|eposition-parent-relati?|eposition-parent-rela?|esult|etain|etry-cancel|eturn-to-start-dir?|eturns|everse-from|evert|evoke|ight|ight-aligned?|ight-align|ow-created|ow-deleted|ow-height|ow-modified|ow-of|ow-unmodified|ule|ule-row|ule-y|un-procedure?|un-procedu?|un-proce?|ecall|esume-display|ight-end|eports|ow-display|ow-entry|ow-leave|ead-response))\\b(?![#$\\-_%&])",
       "captures": {
         "1": {
           "name": "keyword.other.abl"
@@ -4162,7 +4161,7 @@
     },
     "keywords-S": {
       "comment": "The keyword must not have a trailing variable character (one of #$-_%&)",
-      "match": "(?i)\\b((sax-comple(?:te|t)?)|(scrolled-row-pos(?:ition|itio|iti|it|i)?)|(set-pointer-val(?:ue|u)?)|(share(?:-lock|-loc|-lo|-l|-)?)|(show-stat(?:s)?)|(side-lab(?:el|e)?)|(size-c(?:hars|har|ha|h)?)|(size-p(?:ixels|ixel|ixe|ix|i)?)|(stored-proc(?:edure|edur|edu|ed|e)?)|(sub-ave(?:rage|rag|ra|r)?)|(sub-max(?:imum|imu|im|i)?)|(sub-min(?:imum|imu|im|i)?)|(substr(?:ing|in|i)?)|save|save-as|sax-attributes|sax-parser-error|sax-reader|sax-running|sax-uninitialized|sax-write-begin|sax-write-complete|sax-write-content|sax-write-element|sax-write-error|sax-write-idle|sax-write-tag|sax-writer|sax-xml|schema|screen|screen-io|scroll|scroll-bars|scroll-horizontal|scroll-left|scroll-mode|scroll-notify|scroll-right|scroll-vertical|scrollbar-drag|scrolling|search-self|search-target|section|security-policy|seek|select|select-extend|select-on-join|select-repositioned-row|selected-items|selection|selection-extend|selection-list|self|send|sensitive|separate-connection|separators|serializable|serialize-hidden|serialize-name|server|server-socket|session|set|set-attr-call-type|set-byte-order|set-cell-focus|set-contents|set-db-logging|set-event-manager-option|set-option|set-state|settings|shared|short|signature|silent|simple|single|single-character|single-run|size|skip|skip-group-duplicates|skip-schema-check|slider|smallint|soap-fault|soap-header|soap-header-entryref|socket|some|source|source-procedure|space|sql|start|start-box-selection|start-extend-box-selection|start-mem-check|start-move|start-resize|start-row-resize|start-search|starting|static|status|status-area|status-area-msg|stdcall|stomp-detection|stomp-frequency|stop|stop-after|stop-display|stop-mem-check|stream|stream-handle|stream-io|string-xref|sub-count|sub-menu|sub-menu-help|sub-total|subscribe|sum|summary|super|suspend|system-dialog|system-help)\\b(?![#$\\-_%&])",
+      "match": "(?i)\\b(s(?:croll-bars|ensitive|eparators|erialize-hidden|erialize-name|ingle-run|tatus-area|tored-procedure?|tored-procedu?|tored-proce?|ax-attributes|ax-reader|ax-writer|erver|erver-socket|oap-header|oap-header-entryref|ocket|end|tream|ub-menu|creen|uper|ave|croll|eek|et|et-byte-order|et-pointer-value?|et-pointer-val|how-stats?|tatus|top|ubscribe|ubstring?|ubstri?|ystem-dialog|ystem-help|ave-as|ax-complete?|ax-comple|ax-parser-error|ax-running|ax-uninitialized|ax-write-begin|ax-write-complete|ax-write-content|ax-write-element|ax-write-error|ax-write-idle|ax-write-tag|ax-xml|chema|creen-io|crolled-row-position?|crolled-row-positi?|crolled-row-posi?|crolling|earch-self|earch-target|ection|ecurity-policy|elect|elect-on-join|elect-repositioned-row|elected-items|election-list|elf|eparate-connection|erializable|ession|et-attr-call-type|et-cell-focus|et-contents|et-db-logging|et-event-manager-option|et-option|et-state|hare-lock?|hare-lo?|hare-?|hared|hort|ide-label?|ide-lab|ignature|ilent|imple|ingle|ingle-character|ize|ize-chars?|ize-cha?|ize-c|ize-pixels?|ize-pixe?|ize-pi?|kip|kip-group-duplicates|kip-schema-check|lider|mallint|oap-fault|ome|ource|ource-procedure|pace|ql|tart|tart-mem-check|tarting|tatic|tatus-area-msg|tdcall|tomp-detection|tomp-frequency|top-after|top-mem-check|tream-handle|tream-io|tring-xref|ub-average?|ub-avera?|ub-ave|ub-count|ub-maximum?|ub-maxim?|ub-max|ub-menu-help|ub-minimum?|ub-minim?|ub-min|ub-total|um|ummary|uspend|top-display|ettings|croll-left|croll-right|election|election-extend|elect-extend|tart-move|tart-resize|tart-box-selection|tart-extend-box-selection|croll-mode|crollbar-drag|tart-search|croll-notify|tart-row-resize|croll-vertical|croll-horizontal))\\b(?![#$\\-_%&])",
       "captures": {
         "1": {
           "name": "keyword.other.abl"
@@ -4171,7 +4170,7 @@
     },
     "keywords-T": {
       "comment": "The keyword must not have a trailing variable character (one of #$-_%&)",
-      "match": "(?i)\\b((text-seg(?:-growth|-growt|-grow|-gro|-gr|-g|-)?)|(transact(?:ion|io|i)?)|tab|table-scan|target|target-procedure|temp-table|tenant|tenant-where|term|terminal|terminate|text|text-cursor|then|this-object|this-procedure|three-d|through|throw|thru|title|to|tooltip|top|top-column|topic|total|trailing|trans|transaction-mode|trigger|triggers|true|ttcodepage)\\b(?![#$\\-_%&])",
+      "match": "(?i)\\b(t(?:hree-d|itle|ooltip|ransaction?|ransacti?|hrow|emp-table|erminate|riggers|hrough|o|erminal|his-object|ransaction-mode|rigger|able-scan|arget|arget-procedure|enant|enant-where|erm|ext|ext-cursor|ext-seg-growth?|ext-seg-grow?|ext-seg-gr?|ext-seg-?|hen|his-procedure|hru|op|opic|otal|railing|rans|rue|tcodepage|ab|op-column))\\b(?![#$\\-_%&])",
       "captures": {
         "1": {
           "name": "keyword.other.abl"
@@ -4180,7 +4179,7 @@
     },
     "keywords-U": {
       "comment": "The keyword must not have a trailing variable character (one of #$-_%&)",
-      "match": "(?i)\\b((unbuff(?:ered|ere|er|e)?)|(underl(?:ine|in|i)?)|(unform(?:atted|atte|att|at|a)?)|(use-dic(?:t-exps|t-exp|t-ex|t-e|t-|t)?)|undo|union|unique|unix|unix-end|unless-hidden|unload|unsigned-byte|unsigned-int64|unsigned-integer|unsigned-long|unsigned-short|unsubscribe|up|update|upper|use|use-filename|use-index|use-revvideo|use-text|use-underline|use-widget-pool|user|using|utc-offset)\\b(?![#$\\-_%&])",
+      "match": "(?i)\\b(u(?:ndo|nderline?|nderli?|nix|nload|nsubscribe|p|pdate|se|sing|nbuffered?|nbuffer?|nbuff|nformatted?|nformatt?|nforma?|nion|nique|nless-hidden|nsigned-byte|nsigned-int64|nsigned-integer|nsigned-long|nsigned-short|pper|se-dict-exps?|se-dict-ex?|se-dict-?|se-dic|se-filename|se-index|se-revvideo|se-text|se-underline|se-widget-pool|ser|tc-offset|nix-end))\\b(?![#$\\-_%&])",
       "captures": {
         "1": {
           "name": "keyword.other.abl"
@@ -4189,7 +4188,7 @@
     },
     "keywords-V": {
       "comment": "The keyword must not have a trailing variable character (one of #$-_%&)",
-      "match": "(?i)\\b((vari(?:able|abl|ab|a)?)|(verb(?:ose|os|o)?)|(vert(?:ical|ica|ic|i)?)|v6frame|validate|value-changed|values|var|view|view-as|virtual-height|virtual-width|vms|void)\\b(?![#$\\-_%&])",
+      "match": "(?i)\\b(view-as|(var(?:i(?:able?|ab?|))?)|validate|var|view|v6frame|values|verbose?|verbo?|vertical?|vertic?|vert|virtual-height|virtual-width|vms|void|value-changed)\\b(?![#$\\-_%&])",
       "captures": {
         "1": {
           "name": "keyword.other.abl"
@@ -4198,7 +4197,7 @@
     },
     "keywords-W": {
       "comment": "The keyword must not have a trailing variable character (one of #$-_%&)",
-      "match": "(?i)\\b((web-con(?:text|tex|te|t)?)|(window-delayed-min(?:imize|imiz|imi|im|i)?)|(work-tab(?:le|l)?)|wait|wait-for|warning|web-notify|when|where|while|widget|widget-pool|width|window-close|window-maximized|window-minimized|window-name|window-normal|window-resized|window-restored|with|word-index|workfile)\\b(?![#$\\-_%&])",
+      "match": "(?i)\\b(w(?:arning|idget|idget-pool|ork-table?|ork-tab|orkfile|ait-for|ait|eb-context?|eb-conte?|eb-con|hen|here|hile|idth|indow-delayed-minimize?|indow-delayed-minimi?|indow-delayed-mini?|indow-maximized?|indow-maximiz?|indow-maxim|indow-minimized?|indow-minimiz?|indow-minim|indow-name|indow-normal|ith|ord-index|indow-close|indow-restored|indow-resized|eb-notify))\\b(?![#$\\-_%&])",
       "captures": {
         "1": {
           "name": "keyword.other.abl"
@@ -4207,7 +4206,7 @@
     },
     "keywords-X": {
       "comment": "The keyword must not have a trailing variable character (one of #$-_%&)",
-      "match": "(?i)\\b(x-document|x-noderef|x-of|xcode|xml-data-type|xml-node-name|xml-node-type|xor|xref|xref-xml)\\b(?![#$\\-_%&])",
+      "match": "(?i)\\b(x(?:ml-data-type|ml-node-name|ml-node-type|-document|-noderef|-of|code|or|ref|ref-xml))\\b(?![#$\\-_%&])",
       "captures": {
         "1": {
           "name": "keyword.other.abl"
@@ -4216,7 +4215,7 @@
     },
     "keywords-Y": {
       "comment": "The keyword must not have a trailing variable character (one of #$-_%&)",
-      "match": "(?i)\\b(y-of|year|year-offset|yes|yes-no|yes-no-cancel)\\b(?![#$\\-_%&])",
+      "match": "(?i)\\b(y(?:-of|ear|ear-offset|es|es-no|es-no-cancel))\\b(?![#$\\-_%&])",
       "captures": {
         "1": {
           "name": "keyword.other.abl"
@@ -4300,7 +4299,7 @@
       ]
     },
     "handle-attributes-A": {
-      "match": "(?i)(:)((ambig(?:uous|uou|uo|u)?)|(appl-alert(?:-boxes|-boxe|-box|-bo|-b|-)?)|(attr(?:-space|-spac|-spa|-sp|-s|-)?)|(auto-comp(?:letion|letio|leti|let|le|l)?)|(auto-ind(?:ent|en|e)?)|(auto-ret(?:urn|ur|u)?)|(auto-val(?:idate|idat|ida|id|i)?)|(auto-z(?:ap|a)?)|(avail(?:able|abl|ab|a)?)|accelerator|active|actor|adm-data|after-buffer|after-rowid|after-table|allow-column-searching|allow-prev-deserialization|always-on-top|appl-context-id|appserver-info|appserver-password|appserver-userid|async-request-count|async-request-handle|asynchronous|attached-pairlist|attribute-names|audit-event-context|auto-delete|auto-delete-xml|auto-end-key|auto-go|auto-resize|auto-synchronize|available-formats)\\b(?![#$\\-_%&])",
+      "match": "(?i)(:)(a(?:ccelerator|ctive|ctor|dm-data|fter-buffer|fter-rowid|fter-table|llow-column-searching|llow-prev-deserialization|lways-on-top|mbiguous?|mbiguo?|mbig|ppl-alert-boxes?|ppl-alert-box?|ppl-alert-b?|ppl-alert|ppl-context-id|ppserver-info|ppserver-password|ppserver-userid|synchronous|sync-request-count|sync-request-handle|ttached-pairlist|ttribute-names|ttr-space?|ttr-spa?|ttr-s?|ttr|udit-event-context|uto-completion?|uto-completi?|uto-comple?|uto-comp|uto-delete|uto-delete-xml|uto-end-key|uto-go|uto-indent?|uto-inde?|uto-resize|uto-return?|uto-retu?|uto-synchronize|uto-validate?|uto-valida?|uto-vali?|uto-zap?|uto-z|vailable?|vailab?|vail|vailable-formats))\\b(?![#$\\-_%&])",
       "captures": {
         "1": {
           "name": "punctuation.separator.colon.abl"
@@ -4311,7 +4310,7 @@
       }
     },
     "handle-attributes-B": {
-      "match": "(?i)(:)((back(?:ground|groun|grou|gro|gr|g)?)|(bgc(?:olor|olo|ol|o)?)|(border-bottom-c(?:hars|har|ha|h)?)|(border-bottom-p(?:ixels|ixel|ixe|ix|i)?)|(border-left-c(?:hars|har|ha|h)?)|(border-left-p(?:ixels|ixel|ixe|ix|i)?)|(border-right-c(?:hars|har|ha|h)?)|(border-right-p(?:ixels|ixel|ixe|ix|i)?)|(border-top-c(?:hars|har|ha|h)?)|(border-top-p(?:ixels|ixel|ixe|ix|i)?)|(box-select(?:able|abl|ab|a)?)|(buffer-n(?:ame|am|a)?)|base-ade|basic-logging|batch-mode|batch-size|before-buffer|before-rowid|before-table|blank|block-iteration-display|box|buffer-chars|buffer-field|buffer-group-id|buffer-group-name|buffer-handle|buffer-lines|buffer-partition-id|buffer-tenant-id|buffer-tenant-name|bytes-read|bytes-written)\\b(?![#$\\-_%&])",
+      "match": "(?i)(:)(b(?:ackground?|ackgrou?|ackgr?|ack|ase-ade|asic-logging|atch-mode|atch-size|efore-buffer|efore-rowid|efore-table|gcolor?|gcol?|gc|lank|lock-iteration-display|order-bottom-chars?|order-bottom-cha?|order-bottom-c|order-bottom-pixels?|order-bottom-pixe?|order-bottom-pi?|order-left-chars?|order-left-cha?|order-left-c|order-left-pixels?|order-left-pixe?|order-left-pi?|order-right-chars?|order-right-cha?|order-right-c|order-right-pixels?|order-right-pixe?|order-right-pi?|order-top-chars?|order-top-cha?|order-top-c|order-top-pixels?|order-top-pixe?|order-top-pi?|ox|ox-selectable?|ox-selectab?|ox-select|uffer-chars|uffer-field|uffer-group-id|uffer-group-name|uffer-handle|uffer-lines|uffer-name?|uffer-na?|uffer-partition-id|uffer-tenant-id|uffer-tenant-name|ytes-read|ytes-written))\\b(?![#$\\-_%&])",
       "captures": {
         "1": {
           "name": "punctuation.separator.colon.abl"
@@ -4322,7 +4321,7 @@
       }
     },
     "handle-attributes-C": {
-      "match": "(?i)(:)((can-crea(?:te|t)?)|(can-dele(?:te|t)?)|(can-writ(?:e)?)|(case-sen(?:sitive|sitiv|siti|sit|si|s)?)|(center(?:ed|e)?)|(column(?:s)?)|(column-bgc(?:olor|olo|ol|o)?)|(column-fgc(?:olor|olo|ol|o)?)|(column-lab(?:el|e)?)|(column-pfc(?:olor|olo|ol|o)?)|(column-sc(?:rolling|rollin|rolli|roll|rol|ro|r)?)|(convert-3d(?:-colors|-color|-colo|-col|-co|-c|-)?)|(cpint(?:ernal|erna|ern|er|e)?)|(crc-val(?:ue|u)?)|(current-env(?:ironment|ironmen|ironme|ironm|iron|iro|ir|i)?)|cache|call-name|call-type|can-do-domain-support|can-read|cancel-button|cancelled|careful-paint|charset|checked|child-buffer|child-num|class-type|client-connection-id|client-tty|client-type|client-workstation|code|codepage|column-dcolor|column-font|column-movable|column-read-only|column-resizable|com-handle|complete|config-name|context-help|context-help-file|context-help-id|control-box|coverage|cpcase|cpcoll|cplog|cpprint|cprcodein|cprcodeout|cpstream|cpterm|current-changed|current-column|current-iteration|current-request-info|current-response-info|current-result-row|current-row-modified|current-window|cursor-char|cursor-line|cursor-offset)\\b(?![#$\\-_%&])",
+      "match": "(?i)(:)(c(?:ache|all-name|all-type|ancel-button|ancelled|an-create?|an-crea|an-delete?|an-dele|an-do-domain-support|an-read|an-write?|areful-paint|ase-sensitive?|ase-sensiti?|ase-sensi?|ase-sen|entered?|enter|harset|hecked|hild-buffer|hild-num|lass-type|lient-connection-id|lient-tty|lient-type|lient-workstation|ode|odepage|olumns?|olumn-bgcolor?|olumn-bgcol?|olumn-bgc|olumn-dcolor|olumn-fgcolor?|olumn-fgcol?|olumn-fgc|olumn-font|olumn-label?|olumn-lab|olumn-movable|olumn-pfcolor?|olumn-pfcol?|olumn-pfc|olumn-read-only|olumn-resizable|olumn-scrolling?|olumn-scrolli?|olumn-scrol?|olumn-scr?|om-handle|omplete|onfig-name|ontext-help|ontext-help-file|ontext-help-id|ontrol-box|onvert-3d-colors?|onvert-3d-colo?|onvert-3d-co?|onvert-3d-?|overage|pcase|pcoll|pinternal?|pintern?|pinte?|plog|pprint|prcodein|prcodeout|pstream|pterm|rc-value?|rc-val|urrent-changed|urrent-column|urrent-environment?|urrent-environme?|urrent-environ?|urrent-envir?|urrent-env|urrent-iteration|urrent-request-info|urrent-response-info|urrent-result-row|urrent-row-modified|urrent-window|ursor-char|ursor-line|ursor-offset))\\b(?![#$\\-_%&])",
       "captures": {
         "1": {
           "name": "punctuation.separator.colon.abl"
@@ -4333,7 +4332,7 @@
       }
     },
     "handle-attributes-D": {
-      "match": "(?i)(:)((data-entry-ret(?:urn|ur|u)?)|(data-t(?:ype|yp|y)?)|(date-f(?:ormat|orma|orm|or|o)?)|(dde-i(?:d)?)|(default-but(?:ton|to|t)?)|(descript(?:ion|io|i)?)|(display-t(?:ype|yp|y)?)|data-source|data-source-complete-map|data-source-modified|data-source-rowid|dataset|db-context|db-list|db-references|dbname|dcolor|dde-error|dde-item|dde-name|dde-topic|deblank|debug-alert|decimals|default|default-buffer-handle|default-commit|default-string|default-value|delimiter|directory|disable-auto-zap|display-timezone|domain-description|domain-name|domain-type|down|drag-enabled|drop-target|dynamic)\\b(?![#$\\-_%&])",
+      "match": "(?i)(:)(d(?:ata-entry-return?|ata-entry-retu?|ata-source|ata-source-complete-map|ata-source-modified|ata-source-rowid|ata-type?|ata-ty?|ataset|ate-format?|ate-form?|ate-fo?|b-context|b-list|b-references|bname|color|de-error|de-id?|de-item|de-name|de-topic|eblank|ebug-alert|ecimals|efault|efault-buffer-handle|efault-button?|efault-butt?|efault-commit|efault-string|efault-value|elimiter|escription?|escripti?|irectory|isable-auto-zap|isplay-timezone|isplay-type?|isplay-ty?|omain-description|omain-name|omain-type|own|rag-enabled|rop-target|ynamic))\\b(?![#$\\-_%&])",
       "captures": {
         "1": {
           "name": "punctuation.separator.colon.abl"
@@ -4344,7 +4343,7 @@
       }
     },
     "handle-attributes-E": {
-      "match": "(?i)(:)((edge-c(?:hars|har|ha|h)?)|(edge-p(?:ixels|ixel|ixe|ix|i)?)|(error-col(?:umn|um|u)?)|(event-t(?:ype|yp|y)?)|edit-can-paste|edit-can-undo|empty|enabled|encoding|encryption-salt|end-user-prompt|entity-expansion-limit|entry-types-list|error|error-object|error-object-detail|error-row|error-stack-trace|error-string|event-group-id|event-handler|event-handler-object|event-procedure|event-procedure-context|exclusive-id|execution-log|exit-code|expand|expandable|extent)\\b(?![#$\\-_%&])",
+      "match": "(?i)(:)(e(?:dge-chars?|dge-cha?|dge-c|dge-pixels?|dge-pixe?|dge-pi?|dit-can-paste|dit-can-undo|mpty|nabled|ncoding|ncryption-salt|nd-user-prompt|ntity-expansion-limit|ntry-types-list|rror|rror-column?|rror-colu?|rror-object|rror-object-detail|rror-row|rror-stack-trace|rror-string|vent-group-id|vent-handler|vent-handler-object|vent-procedure|vent-procedure-context|vent-type?|vent-ty?|xclusive-id|xecution-log|xit-code|xpand|xpandable|xtent))\\b(?![#$\\-_%&])",
       "captures": {
         "1": {
           "name": "punctuation.separator.colon.abl"
@@ -4355,7 +4354,7 @@
       }
     },
     "handle-attributes-F": {
-      "match": "(?i)(:)((fgc(?:olor|olo|ol|o)?)|(file-create-d(?:ate|at|a)?)|(file-create-t(?:ime|im|i)?)|(file-mod-d(?:ate|at|a)?)|(file-mod-t(?:ime|im|i)?)|(file-off(?:set|se|s)?)|(first-async(?:-request|-reques|-reque|-requ|-req|-re|-r|-)?)|(first-proc(?:edure|edur|edu|ed|e)?)|(first-serv(?:er|e)?)|(first-tab-i(?:tem|te|t)?)|(fore(?:ground|groun|grou|gro|gr|g)?)|(form(?:at|a)?)|(formatte(?:d)?)|(fragmen(?:t)?)|(fram(?:e)?)|(frame-spa(?:cing|cin|ci|c)?)|(full-height-c(?:hars|har|ha|h)?)|(full-height-p(?:ixels|ixel|ixe|ix|i)?)|(full-pathn(?:ame|am|a)?)|(full-width(?:-chars|-char|-cha|-ch|-c|-)?)|(full-width-p(?:ixels|ixel|ixe|ix|i)?)|file-name|file-size|file-type|fill-mode|fill-where-string|filled|first-buffer|first-child|first-column|first-data-source|first-dataset|first-form|first-object|first-query|first-server-socket|first-socket|fit-last-column|flat-button|focused-row|focused-row-selected|font|foreign-key-hidden|form-input|form-long-input|forward-only|frame-col|frame-name|frame-row|frame-x|frame-y|frequency|function)\\b(?![#$\\-_%&])",
+      "match": "(?i)(:)(f(?:gcolor?|gcol?|gc|ile-create-date?|ile-create-da?|ile-create-time?|ile-create-ti?|ile-mod-date?|ile-mod-da?|ile-mod-time?|ile-mod-ti?|ile-name|ile-offset?|ile-offs?|ile-size|ile-type|illed|ill-mode|ill-where-string|irst-async-request?|irst-async-reque?|irst-async-req?|irst-async-r?|irst-async|irst-buffer|irst-child|irst-column|irst-dataset|irst-data-source|irst-form|irst-object|irst-procedure?|irst-procedu?|irst-proce?|irst-query|irst-server?|irst-serv|irst-server-socket|irst-socket|irst-tab-item?|irst-tab-it?|it-last-column|lat-button|ocused-row|ocused-row-selected|ont|oreground?|oregrou?|oregr?|ore|oreign-key-hidden|orm-input|orm-long-input|ormat?|orm|ormatted?|orward-only|ragment?|rame?|rame-col|rame-name|rame-row|rame-spacing?|rame-spaci?|rame-spa|rame-x|rame-y|requency|ull-height-chars?|ull-height-cha?|ull-height-c|ull-height-pixels?|ull-height-pixe?|ull-height-pi?|ull-pathname?|ull-pathna?|ull-width-chars?|ull-width-cha?|ull-width-c?|ull-width|ull-width-pixels?|ull-width-pixe?|ull-width-pi?|unction))\\b(?![#$\\-_%&])",
       "captures": {
         "1": {
           "name": "punctuation.separator.colon.abl"
@@ -4366,7 +4365,7 @@
       }
     },
     "handle-attributes-G": {
-      "match": "(?i)(:)((graphic-e(?:dge|dg|d)?)|(grid-factor-h(?:orizontal|orizonta|orizont|orizon|orizo|oriz|ori|or|o)?)|(grid-factor-v(?:ertical|ertica|ertic|erti|ert|er|e)?)|(grid-unit-height-c(?:hars|har|ha|h)?)|(grid-unit-height-p(?:ixels|ixel|ixe|ix|i)?)|(grid-unit-width-c(?:hars|har|ha|h)?)|(grid-unit-width-p(?:ixels|ixel|ixe|ix|i)?)|grid-snap|grid-visible|group-box)\\b(?![#$\\-_%&])",
+      "match": "(?i)(:)(gr(?:aphic-edge?|aphic-ed?|id-factor-horizontal?|id-factor-horizont?|id-factor-horizo?|id-factor-hori?|id-factor-ho?|id-factor-vertical?|id-factor-vertic?|id-factor-vert?|id-factor-ve?|id-snap|id-unit-height-chars?|id-unit-height-cha?|id-unit-height-c|id-unit-height-pixels?|id-unit-height-pixe?|id-unit-height-pi?|id-unit-width-chars?|id-unit-width-cha?|id-unit-width-c|id-unit-width-pixels?|id-unit-width-pixe?|id-unit-width-pi?|id-visible|oup-box))\\b(?![#$\\-_%&])",
       "captures": {
         "1": {
           "name": "punctuation.separator.colon.abl"
@@ -4377,7 +4376,7 @@
       }
     },
     "handle-attributes-H": {
-      "match": "(?i)(:)((height-c(?:hars|har|ha|h)?)|(height-p(?:ixels|ixel|ixe|ix|i)?)|(hori(?:zontal|zonta|zont|zon|zo|z)?)|handle|handler|has-lobs|has-records|help|hidden|html-charset|html-end-of-line|html-end-of-page|html-frame-begin|html-frame-end|html-header-begin|html-header-end|html-title-begin|html-title-end|hwnd)\\b(?![#$\\-_%&])",
+      "match": "(?i)(:)(h(?:andler??|as-lobs|as-records|eight-chars?|eight-cha?|eight-c|eight-pixels?|eight-pixe?|eight-pi?|elp|idden|orizontal?|orizont?|orizo?|ori|tml-charset|tml-end-of-line|tml-end-of-page|tml-frame-begin|tml-frame-end|tml-header-begin|tml-header-end|tml-title-begin|tml-title-end|wnd))\\b(?![#$\\-_%&])",
       "captures": {
         "1": {
           "name": "punctuation.separator.colon.abl"
@@ -4388,7 +4387,7 @@
       }
     },
     "handle-attributes-I": {
-      "match": "(?i)(:)((icfparam(?:eter|ete|et|e)?)|(ignore-current-mod(?:ified|ifie|ifi|if|i)?)|(index-info(?:rmation|rmatio|rmati|rmat|rma|rm|r)?)|(inherit-bgc(?:olor|olo|ol|o)?)|(inherit-fgc(?:olor|olo|ol|o)?)|(is-clas(?:s)?)|(is-partitione(?:d)?)|icon|image|image-down|image-insensitive|image-up|immediate-display|in-handle|index|initial|inner-chars|inner-lines|input-value|instantiating-procedure|internal-entries|is-json|is-multi-tenant|is-open|is-parameter-set|is-xml|items-per-row)\\b(?![#$\\-_%&])",
+      "match": "(?i)(:)(i(?:cfparameter?|cfparamet?|cfparam|con|gnore-current-modified?|gnore-current-modifi?|gnore-current-modi?|mage|mage-down|mage-insensitive|mage-up|mmediate-display|ndex|ndex-information?|ndex-informati?|ndex-informa?|ndex-infor?|n-handle|nherit-bgcolor?|nherit-bgcol?|nherit-bgc|nherit-fgcolor?|nherit-fgcol?|nherit-fgc|nitial|nner-chars|nner-lines|nput-value|nstantiating-procedure|nternal-entries|s-class?|s-json|s-multi-tenant|s-open|s-parameter-set|s-partitioned?|s-xml|tems-per-row))\\b(?![#$\\-_%&])",
       "captures": {
         "1": {
           "name": "punctuation.separator.colon.abl"
@@ -4399,7 +4398,7 @@
       }
     },
     "handle-attributes-K": {
-      "match": "(?i)(:)((keep-frame-z(?:-order|-orde|-ord|-or|-o|-)?)|keep-connection-open|keep-security-cache|key|keys)\\b(?![#$\\-_%&])",
+      "match": "(?i)(:)(ke(?:ep-connection-open|ep-frame-z-order?|ep-frame-z-ord?|ep-frame-z-o?|ep-frame-z|ep-security-cache|ys??))\\b(?![#$\\-_%&])",
       "captures": {
         "1": {
           "name": "punctuation.separator.colon.abl"
@@ -4410,7 +4409,7 @@
       }
     },
     "handle-attributes-L": {
-      "match": "(?i)(:)((label-bgc(?:olor|olo|ol|o)?)|(label-dc(?:olor|olo|ol|o)?)|(label-fgc(?:olor|olo|ol|o)?)|(language(?:s)?)|(last-async(?:-request|-reques|-reque|-requ|-req|-re|-r|-)?)|(last-proce(?:dure|dur|du|d)?)|(last-serv(?:er|e)?)|(last-tab-i(?:tem|te|t)?)|label|label-font|labels|labels-have-colons|large|large-to-small|last-batch|last-child|last-form|last-object|last-server-socket|last-socket|length|library|library-calling-convention|line|list-item-pairs|list-items|listings|literal-question|local-host|local-name|local-port|local-version-info|locator-column-number|locator-line-number|locator-public-id|locator-system-id|locator-type|locked|log-entry-types|log-threshold|logfile-name|logging-level|login-expiration-timestamp|login-host|login-state)\\b(?![#$\\-_%&])",
+      "match": "(?i)(:)(l(?:abel|abel-bgcolor?|abel-bgcol?|abel-bgc|abel-dcolor?|abel-dcol?|abel-dc|abel-fgcolor?|abel-fgcol?|abel-fgc|abel-font|abels|abels-have-colons|anguages?|arge|arge-to-small|ast-async-request?|ast-async-reque?|ast-async-req?|ast-async-r?|ast-async|ast-batch|ast-child|ast-form|ast-object|ast-procedure?|ast-procedu?|ast-proce|ast-server?|ast-serv|ast-server-socket|ast-socket|ast-tab-item?|ast-tab-it?|ength|ibrary|ibrary-calling-convention|ine|ist-item-pairs|ist-items|istings|iteral-question|ocal-host|ocal-name|ocal-port|ocal-version-info|ocator-column-number|ocator-line-number|ocator-public-id|ocator-system-id|ocator-type|ocked|og-entry-types|og-threshold|ogfile-name|ogging-level|ogin-expiration-timestamp|ogin-host|ogin-state))\\b(?![#$\\-_%&])",
       "captures": {
         "1": {
           "name": "punctuation.separator.colon.abl"
@@ -4421,7 +4420,7 @@
       }
     },
     "handle-attributes-M": {
-      "match": "(?i)(:)((max-height-c(?:hars|har|ha|h)?)|(max-height-p(?:ixels|ixel|ixe|ix|i)?)|(max-val(?:ue|u)?)|(max-width-c(?:hars|har|ha|h)?)|(max-width-p(?:ixels|ixel|ixe|ix|i)?)|(menu-k(?:ey|e)?)|(menu-m(?:ouse|ous|ou|o)?)|(min-column-width-c(?:hars|har|ha|h)?)|(min-column-width-p(?:ixels|ixel|ixe|ix|i)?)|(min-height-c(?:hars|har|ha|h)?)|(min-height-p(?:ixels|ixel|ixe|ix|i)?)|(min-schema-marshal(?:l)?)|(min-val(?:ue|u)?)|(min-width-c(?:hars|har|ha|h)?)|(min-width-p(?:ixels|ixel|ixe|ix|i)?)|(mouse-p(?:ointer|ointe|oint|oin|oi|o)?)|mandatory|manual-highlight|max-button|max-chars|max-data-guess|maximum-level|menu-bar|merge-by-field|message-area|message-area-font|min-button|modified|movable|multi-compile|multiple|multitasking-interval|must-understand)\\b(?![#$\\-_%&])",
+      "match": "(?i)(:)(m(?:andatory|anual-highlight|ax-button|ax-chars|ax-data-guess|ax-height-chars?|ax-height-cha?|ax-height-c|ax-height-pixels?|ax-height-pixe?|ax-height-pi?|aximum-level|ax-value?|ax-val|ax-width-chars?|ax-width-cha?|ax-width-c|ax-width-pixels?|ax-width-pixe?|ax-width-pi?|enu-bar|enu-key?|enu-k|enu-mouse?|enu-mou?|enu-m|erge-by-field|essage-area|essage-area-font|in-button|in-column-width-chars?|in-column-width-cha?|in-column-width-c|in-column-width-pixels?|in-column-width-pixe?|in-column-width-pi?|in-height-chars?|in-height-cha?|in-height-c|in-height-pixels?|in-height-pixe?|in-height-pi?|in-schema-marshall?|in-value?|in-val|in-width-chars?|in-width-cha?|in-width-c|in-width-pixels?|in-width-pixe?|in-width-pi?|odified|ouse-pointer?|ouse-point?|ouse-poi?|ouse-p|ovable|ulti-compile|ultiple|ultitasking-interval|ust-understand))\\b(?![#$\\-_%&])",
       "captures": {
         "1": {
           "name": "punctuation.separator.colon.abl"
@@ -4432,7 +4431,7 @@
       }
     },
     "handle-attributes-N": {
-      "match": "(?i)(:)((next-col(?:umn|um|u)?)|(next-tab-ite(?:m)?)|(no-schema-marshal(?:l)?)|(no-val(?:idate|idat|ida|id|i)?)|(num-but(?:tons|ton|to|t)?)|(num-col(?:umns|umn|um|u)?)|(num-locked-col(?:umns|umn|um|u)?)|(num-repl(?:aced|ace|ac|a)?)|(num-visible-col(?:umns|umn|um|u)?)|(numeric-dec(?:imal-point|imal-poin|imal-poi|imal-po|imal-p|imal-|imal|ima|im|i)?)|(numeric-f(?:ormat|orma|orm|or|o)?)|(numeric-sep(?:arator|arato|arat|ara|ar|a)?)|name|namespace-prefix|namespace-uri|needs-appserver-prompt|needs-prompt|nested|new|new-row|next-rowid|next-sibling|no-current-value|no-empty-space|no-focus|node-value|nonamespace-schema-location|num-buffers|num-child-relations|num-children|num-dropped-files|num-entries|num-fields|num-formats|num-header-entries|num-items|num-iterations|num-lines|num-log-files|num-messages|num-parameters|num-references|num-relations|num-results|num-selected-rows|num-selected-widgets|num-source-buffers|num-tabs|num-to-retain|num-top-buffers)\\b(?![#$\\-_%&])",
+      "match": "(?i)(:)(n(?:ame|amespace-prefix|amespace-uri|eeds-appserver-prompt|eeds-prompt|ested|ew|ew-row|ext-column?|ext-colu?|ext-rowid|ext-sibling|ext-tab-item?|o-current-value|o-empty-space|o-focus|onamespace-schema-location|o-schema-marshall?|o-validate?|o-valida?|o-vali?|ode-value|um-buffers|um-buttons?|um-butto?|um-but|um-child-relations|um-children|um-columns?|um-colum?|um-col|um-dropped-files|um-entries|um-fields|um-formats|um-header-entries|um-items|um-iterations|um-lines|um-locked-columns?|um-locked-colum?|um-locked-col|um-log-files|um-messages|um-parameters|um-references|um-relations|um-replaced?|um-replac?|um-repl|um-results|um-selected-rows|um-selected-widgets|um-source-buffers|um-tabs|um-to-retain|um-top-buffers|um-visible-columns?|um-visible-colum?|um-visible-col|umeric-decimal-point?|umeric-decimal-poi?|umeric-decimal-p?|umeric-decimal?|umeric-decim?|umeric-dec|umeric-format?|umeric-form?|umeric-fo?|umeric-separator?|umeric-separat?|umeric-separ?|umeric-sep))\\b(?![#$\\-_%&])",
       "captures": {
         "1": {
           "name": "punctuation.separator.colon.abl"
@@ -4443,7 +4442,7 @@
       }
     },
     "handle-attributes-O": {
-      "match": "(?i)(:)((on-frame(?:-border|-borde|-bord|-bor|-bo|-b|-)?)|options|ordinal|origin-handle|origin-rowid|overlay|owner|owner-document)\\b(?![#$\\-_%&])",
+      "match": "(?i)(:)(o(?:n-frame-border?|n-frame-bord?|n-frame-bo?|n-frame-?|ptions|rdinal|rigin-handle|rigin-rowid|verlay|wner|wner-document))\\b(?![#$\\-_%&])",
       "captures": {
         "1": {
           "name": "punctuation.separator.colon.abl"
@@ -4454,7 +4453,7 @@
       }
     },
     "handle-attributes-P": {
-      "match": "(?i)(:)((page-bot(?:tom|to|t)?)|(param(?:eter|ete|et|e)?)|(parent-rel(?:ation|atio|ati|at|a)?)|(pbe-hash-alg(?:orithm|orith|orit|ori|or|o)?)|(persist(?:ent|en|e)?)|(pfc(?:olor|olo|ol|o)?)|(pixels-per-col(?:umn|um|u)?)|(popup-m(?:enu|en|e)?)|(popup-o(?:nly|nl|n)?)|(prev-col(?:umn|um|u)?)|(prev-tab-i(?:tem|te|t)?)|(private-d(?:ata|at|a)?)|(progress-s(?:ource|ourc|our|ou|o)?)|page-top|parent|parent-buffer|parent-fields-after|parent-fields-before|parent-id-relation|parse-status|password-field|pathname|pbe-key-rounds|persistent-cache-disabled|persistent-procedure|pixels-per-row|position|prefer-dataset|prepare-string|prepared|prev-sibling|primary|primary-passphrase|printer-control-handle|printer-hdc|printer-name|printer-port|procedure-name|procedure-type|profiling|proxy|proxy-password|proxy-userid|public-id|published-events)\\b(?![#$\\-_%&])",
+      "match": "(?i)(:)(p(?:age-bottom?|age-bott?|age-top|arameter?|aramet?|aram|arent|arent-buffer|arent-fields-after|arent-fields-before|arent-id-relation|arent-relation?|arent-relati?|arent-rela?|arse-status|assword-field|athname|be-hash-algorithm?|be-hash-algorit?|be-hash-algor?|be-hash-alg|be-key-rounds|ersistent?|ersiste?|ersistent-cache-disabled|ersistent-procedure|fcolor?|fcol?|fc|ixels-per-column?|ixels-per-colu?|ixels-per-row|opup-menu?|opup-me?|opup-only?|opup-on?|osition|refer-dataset|repared|repare-string|rev-column?|rev-colu?|rev-sibling|rev-tab-item?|rev-tab-it?|rimary|rimary-passphrase|rinter-control-handle|rinter-hdc|rinter-name|rinter-port|rivate-data?|rivate-da?|rocedure-name|rocedure-type|rofiling|rogress-source?|rogress-sour?|rogress-so?|roxy|roxy-password|roxy-userid|ublic-id|ublished-events))\\b(?![#$\\-_%&])",
       "captures": {
         "1": {
           "name": "punctuation.separator.colon.abl"
@@ -4465,7 +4464,7 @@
       }
     },
     "handle-attributes-Q": {
-      "match": "(?i)(:)(qualified-user-id|query|query-off-end|quit)\\b(?![#$\\-_%&])",
+      "match": "(?i)(:)(qu(?:alified-user-id|ery|ery-off-end|it))\\b(?![#$\\-_%&])",
       "captures": {
         "1": {
           "name": "punctuation.separator.colon.abl"
@@ -4476,7 +4475,7 @@
       }
     },
     "handle-attributes-R": {
-      "match": "(?i)(:)((record-len(?:gth|gt|g)?)|(relation-fi(?:elds|eld|el|e)?)|(resiza(?:ble|bl|b)?)|(retain-s(?:hape|hap|ha|h)?)|(return-ins(?:erted|erte|ert|er|e)?)|(return-val(?:ue|u)?)|(row-height-c(?:hars|har|ha|h)?)|(row-height-p(?:ixels|ixel|ixe|ix|i)?)|(row-ma(?:rkers|rker|rke|rk|r)?)|radio-buttons|read-only|recid|recursive|refreshable|rejected|relations-active|remote|remote-host|remote-port|reposition|request-info|resize|response-info|restart-row|restart-rowid|return-value-data-type|return-value-dll-type|role|roles|rounded|row|row-resizable|row-state|rowid)\\b(?![#$\\-_%&])",
+      "match": "(?i)(:)(r(?:adio-buttons|ead-only|ecid|ecord-length?|ecord-leng?|ecursive|efreshable|ejected|elation-fields?|elation-fiel?|elation-fi|elations-active|emote|emote-host|emote-port|eposition|equest-info|esizable?|esizab?|esize|esponse-info|estart-row|estart-rowid|etain-shape?|etain-sha?|etain-s|eturn-inserted?|eturn-insert?|eturn-inse?|eturn-value?|eturn-val|eturn-value-data-type|eturn-value-dll-type|oles??|ounded|ow|ow-height-chars?|ow-height-cha?|ow-height-c|ow-height-pixels?|ow-height-pixe?|ow-height-pi?|ow-state|owid|ow-markers?|ow-marke?|ow-mar?|ow-resizable))\\b(?![#$\\-_%&])",
       "captures": {
         "1": {
           "name": "punctuation.separator.colon.abl"
@@ -4487,7 +4486,7 @@
       }
     },
     "handle-attributes-S": {
-      "match": "(?i)(:)((screen-val(?:ue|u)?)|(scrollbar-h(?:orizontal|orizonta|orizont|orizon|orizo|oriz|ori|or|o)?)|(scrollbar-v(?:ertical|ertica|ertic|erti|ert|er|e)?)|(separator-fgc(?:olor|olo|ol|o)?)|(server-connection-bo(?:und|un|u)?)|(server-connection-bound-re(?:quest|ques|que|qu|q)?)|(server-connection-co(?:ntext|ntex|nte|nt|n)?)|(show-in-task(?:bar|ba|b)?)|(side-label-h(?:andle|andl|and|an|a)?)|(skip-deleted-rec(?:ord|or|o)?)|(stoppe(?:d)?)|(super-proc(?:edures|edure|edur|edu|ed|e)?)|(suppress-w(?:arnings|arning|arnin|arni|arn|ar|a)?)|(system-alert(?:-boxes|-boxe|-box|-bo|-b|-)?)|save-where-string|schema-change|schema-location|schema-marshal|schema-path|screen-lines|scroll-bars|scrollable|seal-timestamp|selectable|selected|selection-end|selection-start|selection-text|sensitive|separators|serialize-hidden|serialize-name|server|server-connection-id|server-operating-mode|session-end|session-id|side-labels|signature-value|single-run|singleton|small-icon|small-title|soap-fault-actor|soap-fault-code|soap-fault-detail|soap-fault-misunderstood-header|soap-fault-node|soap-fault-role|soap-fault-string|soap-fault-subcode|soap-version|sort|sort-ascending|sort-number|ssl-server-name|standalone|startup-parameters|state-detail|statistics|status-area|status-area-font|stop|stop-object|stream|stretch-to-fit|strict|strict-entity-resolution|subtype|suppress-namespace-processing|suppress-warnings-list|symmetric-encryption-aad|symmetric-encryption-algorithm|symmetric-encryption-iv|symmetric-encryption-key|symmetric-support|system-id)\\b(?![#$\\-_%&])",
+      "match": "(?i)(:)(s(?:ave-where-string|chema-change|chema-location|chema-marshal|chema-path|creen-lines|creen-value?|creen-val|croll-bars|crollable|crollbar-horizontal?|crollbar-horizont?|crollbar-horizo?|crollbar-hori?|crollbar-ho?|crollbar-vertical?|crollbar-vertic?|crollbar-vert?|crollbar-ve?|eal-timestamp|electable|elected|election-end|election-start|election-text|ensitive|eparators|eparator-fgcolor?|eparator-fgcol?|eparator-fgc|erialize-hidden|erialize-name|erver|erver-connection-bound?|erver-connection-bou?|erver-connection-bound-request?|erver-connection-bound-reque?|erver-connection-bound-req?|erver-connection-context?|erver-connection-conte?|erver-connection-con?|erver-connection-id|erver-operating-mode|ession-end|ession-id|how-in-taskbar?|how-in-taskb?|ide-label-handle?|ide-label-hand?|ide-label-ha?|ide-labels|ignature-value|ingle-run|ingleton|kip-deleted-record?|kip-deleted-reco?|mall-icon|mall-title|oap-fault-actor|oap-fault-code|oap-fault-detail|oap-fault-misunderstood-header|oap-fault-node|oap-fault-role|oap-fault-string|oap-fault-subcode|oap-version|ort|ort-ascending|ort-number|sl-server-name|tandalone|tartup-parameters|tate-detail|tatistics|tatus-area|tatus-area-font|top|top-object|topped?|tream|tretch-to-fit|trict|trict-entity-resolution|ubtype|uper-procedures?|uper-procedur?|uper-proced?|uper-proc|uppress-namespace-processing|uppress-warnings?|uppress-warnin?|uppress-warn?|uppress-wa?|uppress-warnings-list|ymmetric-encryption-aad|ymmetric-encryption-algorithm|ymmetric-encryption-iv|ymmetric-encryption-key|ymmetric-support|ystem-alert-boxes?|ystem-alert-box?|ystem-alert-b?|ystem-alert|ystem-id))\\b(?![#$\\-_%&])",
       "captures": {
         "1": {
           "name": "punctuation.separator.colon.abl"
@@ -4498,7 +4497,7 @@
       }
     },
     "handle-attributes-T": {
-      "match": "(?i)(:)((table-num(?:ber|be|b)?)|(temp-dir(?:ectory|ector|ecto|ect|ec|e)?)|(title-bgc(?:olor|olo|ol|o)?)|(title-dc(?:olor|olo|ol|o)?)|(title-fgc(?:olor|olo|ol|o)?)|(title-fo(?:nt|n)?)|(trans-init-proc(?:edure|edur|edu|ed|e)?)|(transact(?:ion|io|i)?)|(transpar(?:ent|en|e)?)|tab-position|tab-stop|table|table-crc-list|table-handle|table-list|text-selected|thread-safe|three-d|tic-marks|time-source|timezone|title|toggle-box|tooltip|tooltips|top-nav-query|top-only|trace-filter|tracing|tracking-changes|type)\\b(?![#$\\-_%&])",
+      "match": "(?i)(:)(t(?:ab-position|ab-stop|able|able-crc-list|able-handle|able-list|able-number?|able-numb?|emp-directory?|emp-directo?|emp-direc?|emp-dir|ext-selected|hread-safe|hree-d|ic-marks|ime-source|imezone|itle|itle-bgcolor?|itle-bgcol?|itle-bgc|itle-dcolor?|itle-dcol?|itle-dc|itle-fgcolor?|itle-fgcol?|itle-fgc|itle-font?|itle-fo|oggle-box|ooltips??|op-nav-query|op-only|race-filter|racing|racking-changes|ransaction?|ransacti?|ransparent?|ranspare?|rans-init-procedure?|rans-init-procedu?|rans-init-proce?|ype))\\b(?![#$\\-_%&])",
       "captures": {
         "1": {
           "name": "punctuation.separator.colon.abl"
@@ -4509,7 +4508,7 @@
       }
     },
     "handle-attributes-U": {
-      "match": "(?i)(:)(undo|undo-throw-scope|unique-id|unique-match|url|url-password|url-userid|user-id)\\b(?![#$\\-_%&])",
+      "match": "(?i)(:)(u(?:ndo|ndo-throw-scope|nique-id|nique-match|rl|rl-password|rl-userid|ser-id))\\b(?![#$\\-_%&])",
       "captures": {
         "1": {
           "name": "punctuation.separator.colon.abl"
@@ -4520,7 +4519,7 @@
       }
     },
     "handle-attributes-V": {
-      "match": "(?i)(:)((validate-expressio(?:n)?)|(virtual-height-c(?:hars|har|ha|h)?)|(virtual-height-p(?:ixels|ixel|ixe|ix|i)?)|(virtual-width-c(?:hars|har|ha|h)?)|(virtual-width-p(?:ixels|ixel|ixe|ix|i)?)|v6display|validate-message|validate-xml|validation-enabled|value|version|view-as|view-first-column-on-reopen|visible)\\b(?![#$\\-_%&])",
+      "match": "(?i)(:)(v(?:6display|alidate-expression?|alidate-message|alidate-xml|alidation-enabled|alue|ersion|iew-as|iew-first-column-on-reopen|irtual-height-chars?|irtual-height-cha?|irtual-height-c|irtual-height-pixels?|irtual-height-pixe?|irtual-height-pi?|irtual-width-chars?|irtual-width-cha?|irtual-width-c|irtual-width-pixels?|irtual-width-pixe?|irtual-width-pi?|isible))\\b(?![#$\\-_%&])",
       "captures": {
         "1": {
           "name": "punctuation.separator.colon.abl"
@@ -4531,7 +4530,7 @@
       }
     },
     "handle-attributes-W": {
-      "match": "(?i)(:)((widget-e(?:nter|nte|nt|n)?)|(widget-l(?:eave|eav|ea|e)?)|(width-c(?:hars|har|ha|h)?)|(width-p(?:ixels|ixel|ixe|ix|i)?)|(window-sta(?:te|t)?)|(window-sys(?:tem|te|t)?)|(work-area-height-p(?:ixels|ixel|ixe|ix|i)?)|(work-area-width-p(?:ixels|ixel|ixe|ix|i)?)|warning|wc-admin-app|where-string|widget-id|window|word-wrap|work-area-x|work-area-y|write-status)\\b(?![#$\\-_%&])",
+      "match": "(?i)(:)(w(?:arning|c-admin-app|here-string|idget-enter?|idget-ent?|idget-e|idget-id|idget-leave?|idget-lea?|idget-l|idth-chars?|idth-cha?|idth-c|idth-pixels?|idth-pixe?|idth-pi?|indow|indow-state?|indow-sta|indow-system?|indow-syst?|ord-wrap|ork-area-height-pixels?|ork-area-height-pixe?|ork-area-height-pi?|ork-area-width-pixels?|ork-area-width-pixe?|ork-area-width-pi?|ork-area-x|ork-area-y|rite-status))\\b(?![#$\\-_%&])",
       "captures": {
         "1": {
           "name": "punctuation.separator.colon.abl"
@@ -4542,7 +4541,7 @@
       }
     },
     "handle-attributes-X": {
-      "match": "(?i)(:)((xml-schema-pat(?:h)?)|x|x-document|xcode-session-key|xml-data-type|xml-entity-expansion-limit|xml-node-name|xml-node-type|xml-strict-entity-resolution|xml-suppress-namespace-processing)\\b(?![#$\\-_%&])",
+      "match": "(?i)(:)(x(?:|-document|code-session-key|ml-data-type|ml-entity-expansion-limit|ml-node-name|ml-node-type|ml-schema-path?|ml-strict-entity-resolution|ml-suppress-namespace-processing))\\b(?![#$\\-_%&])",
       "captures": {
         "1": {
           "name": "punctuation.separator.colon.abl"
@@ -4553,7 +4552,7 @@
       }
     },
     "handle-attributes-Y": {
-      "match": "(?i)(:)(y|year-offset)\\b(?![#$\\-_%&])",
+      "match": "(?i)(:)(y(?:|ear-offset))\\b(?![#$\\-_%&])",
       "captures": {
         "1": {
           "name": "punctuation.separator.colon.abl"
@@ -4622,7 +4621,7 @@
       ]
     },
     "handle-methods-A": {
-      "begin": "(?i)(:)((add-calc-col(?:umn|um|u)?)|(add-events-proc(?:edure|edur|edu|ed|e)?)|(add-like-col(?:umn|um|u)?)|(add-rel(?:ation|atio|ati|at|a)?)|(add-super-proc(?:edure|edur|edu|ed|e)?)|accept-changes|accept-row-changes|add-buffer|add-columns-from|add-fields-from|add-first|add-header-entry|add-index-field|add-last|add-like-field|add-like-index|add-new-field|add-new-index|add-parent-id-relation|add-schema-location|add-source-buffer|append-child|apply-callback|attach-data-source|authentication-failed)\\s*(?=\\()",
+      "begin": "(?i)(:)(a(?:ccept-changes|ccept-row-changes|dd-buffer|dd-calc-column?|dd-calc-colu?|dd-columns-from|dd-events-procedure?|dd-events-procedu?|dd-events-proce?|dd-fields-from|dd-first|dd-header-entry|dd-index-field|dd-last|dd-like-column?|dd-like-colu?|dd-like-field|dd-like-index|dd-new-field|dd-new-index|dd-parent-id-relation|dd-relation?|dd-relati?|dd-rela?|dd-schema-location|dd-source-buffer|dd-super-procedure?|dd-super-procedu?|dd-super-proce?|ppend-child|pply-callback|ttach-data-source|uthentication-failed))\\s*(?=\\()",
       "beginCaptures": {
         "1": {
           "name": "punctuation.separator.colon.abl"
@@ -4644,7 +4643,7 @@
       ]
     },
     "handle-methods-B": {
-      "begin": "(?i)(:)((buffer-comp(?:are|ar|a)?)|(buffer-releas(?:e)?)|begin-event-group|buffer-copy|buffer-create|buffer-delete|buffer-export|buffer-export-fields|buffer-field|buffer-import|buffer-import-fields|buffer-validate|buffer-value)\\s*(?=\\()",
+      "begin": "(?i)(:)(b(?:egin-event-group|uffer-compare?|uffer-compa?|uffer-copy|uffer-create|uffer-delete|uffer-export|uffer-export-fields|uffer-field|uffer-import|uffer-import-fields|uffer-release?|uffer-validate|uffer-value))\\s*(?=\\()",
       "beginCaptures": {
         "1": {
           "name": "punctuation.separator.colon.abl"
@@ -4666,7 +4665,7 @@
       ]
     },
     "handle-methods-C": {
-      "begin": "(?i)(:)((clear-select(?:ion|io|i)?)|(clear-sort-arrow(?:s)?)|(convert-to-offs(?:et|e)?)|cancel-break|cancel-requests|cancel-requests-after|clear|clear-appl-context|clear-log|clone-node|close-log|connect|connected|copy-dataset|copy-sax-attributes|copy-temp-table|create-like|create-like-sequential|create-node|create-node-namespace|create-result-list-entry|current-query)\\s*(?=\\()",
+      "begin": "(?i)(:)(c(?:ancel-break|ancel-requests|ancel-requests-after|lear|lear-appl-context|lear-log|lear-selection?|lear-selecti?|lear-sort-arrows?|lone-node|lose-log|onnect|onnected|onvert-to-offset?|onvert-to-offs|opy-dataset|opy-sax-attributes|opy-temp-table|reate-like|reate-like-sequential|reate-node|reate-node-namespace|reate-result-list-entry|urrent-query))\\s*(?=\\()",
       "beginCaptures": {
         "1": {
           "name": "punctuation.separator.colon.abl"
@@ -4688,7 +4687,7 @@
       ]
     },
     "handle-methods-D": {
-      "begin": "(?i)(:)((debu(?:g)?)|(discon(?:nect|nec|ne|n)?)|declare-namespace|delete|delete-char|delete-current-row|delete-header-entry|delete-line|delete-node|delete-result-list-entry|delete-selected-row|delete-selected-rows|deselect-focused-row|deselect-rows|deselect-selected-row|detach-data-source|disable|disable-connections|disable-dump-triggers|disable-load-triggers|display-message|dump-logging-now)\\s*(?=\\()",
+      "begin": "(?i)(:)(d(?:ebug?|eclare-namespace|elete|elete-char|elete-current-row|elete-header-entry|elete-line|elete-node|elete-result-list-entry|elete-selected-rows??|eselect-focused-row|eselect-rows|eselect-selected-row|etach-data-source|isable|isable-connections|isable-dump-triggers|isable-load-triggers|isconnect?|isconne?|iscon|isplay-message|ump-logging-now))\\s*(?=\\()",
       "beginCaptures": {
         "1": {
           "name": "punctuation.separator.colon.abl"
@@ -4710,7 +4709,7 @@
       ]
     },
     "handle-methods-E": {
-      "begin": "(?i)(:)(edit-clear|edit-copy|edit-cut|edit-paste|edit-undo|empty-dataset|empty-temp-table|enable|enable-connections|encode-domain-access-code|encrypt-audit-mac-key|end-document|end-element|end-event-group|end-file-drop|entry|export|export-principal|)\\s*(?=\\()",
+      "begin": "(?i)(:)(e(?:dit-clear|dit-copy|dit-cut|dit-paste|dit-undo|mpty-dataset|mpty-temp-table|nable|nable-connections|ncode-domain-access-code|ncrypt-audit-mac-key|nd-document|nd-element|nd-event-group|nd-file-drop|ntry|xport|xport-principal))\\s*(?=\\()",
       "beginCaptures": {
         "1": {
           "name": "punctuation.separator.colon.abl"
@@ -4732,7 +4731,7 @@
       ]
     },
     "handle-methods-F": {
-      "begin": "(?i)(:)(fetch-selected-row|fill|find-by-rowid|find-current|find-first|find-last|find-unique|first-of)\\s*(?=\\()",
+      "begin": "(?i)(:)(f(?:etch-selected-row|ill|ind-by-rowid|ind-current|ind-first|ind-last|ind-unique|irst-of))\\s*(?=\\()",
       "beginCaptures": {
         "1": {
           "name": "punctuation.separator.colon.abl"
@@ -4754,7 +4753,7 @@
       ]
     },
     "handle-methods-G": {
-      "begin": "(?i)(:)((get-blue(?:-value|-valu|-val|-va|-v|-)?)|(get-browse-col(?:umn|um|u)?)|(get-child-rel(?:ation|atio|ati|at|a)?)|(get-curr(?:ent|en|e)?)|(get-file-offse(?:t)?)|(get-firs(?:t)?)|(get-green(?:-value|-valu|-val|-va|-v|-)?)|(get-header-entr(?:y)?)|(get-red(?:-value|-valu|-val|-va|-v|-)?)|(get-rel(?:ation|atio|ati|at|a)?)|(get-rgb(?:-value|-valu|-val|-va|-v|-)?)|(get-selected(?:-widget|-widge|-widg|-wid|-wi|-w|-)?)|(get-text-height-c(?:hars|har|ha|h)?)|(get-text-height-p(?:ixels|ixel|ixe|ix|i)?)|(get-text-width-c(?:hars|har|ha|h)?)|(get-text-width-p(?:ixels|ixel|ixe|ix|i)?)|(get-wait(?:-state|-stat|-sta|-st|-s|-)?)|get-attribute|get-attribute-node|get-binary-data|get-buffer-handle|get-bytes-available|get-callback-proc-context|get-callback-proc-name|get-cgi-list|get-cgi-long-value|get-cgi-value|get-changes|get-child|get-client|get-column|get-config-value|get-dataset-buffer|get-document-element|get-dropped-file|get-dynamic|get-error-column|get-error-row|get-file-name|get-index-by-namespace-name|get-index-by-qname|get-iteration|get-last|get-localname-by-index|get-message|get-message-type|get-next|get-node|get-number|get-parent|get-prev|get-printers|get-property|get-qname-by-index|get-repositioned-row|get-row|get-safe-user|get-serialized|get-signature|get-socket-option|get-source-buffer|get-tab-item|get-top-buffer|get-type-by-index|get-type-by-namespace-name|get-type-by-qname|get-uri-by-index|get-value-by-index|get-value-by-namespace-name|get-value-by-qname)\\s*(?=\\()",
+      "begin": "(?i)(:)(get-(?:attribute|attribute-node|binary-data|blue-value?|blue-val?|blue-v?|blue|browse-column?|browse-colu?|buffer-handle|bytes-available|callback-proc-context|callback-proc-name|cgi-list|cgi-value|cgi-long-value|changes|child|child-relation?|child-relati?|child-rela?|client|column|config-value|current?|curre?|dataset-buffer|document-element|dropped-file|dynamic|error-column|error-row|file-name|file-offset?|first?|green-value?|green-val?|green-v?|green|header-entry?|index-by-namespace-name|index-by-qname|iteration|last|localname-by-index|message|message-type|next|node|number|parent|prev|property|printers|qname-by-index|red-value?|red-val?|red-v?|red|relation?|relati?|rela?|repositioned-row|rgb-value?|rgb-val?|rgb-v?|rgb|row|safe-user|selected-widget?|selected-widg?|selected-wi?|selected-?|serialized|signature|socket-option|source-buffer|tab-item|text-height-chars?|text-height-cha?|text-height-c|text-height-pixels?|text-height-pixe?|text-height-pi?|text-width-chars?|text-width-cha?|text-width-c|text-width-pixels?|text-width-pixe?|text-width-pi?|top-buffer|type-by-index|type-by-namespace-name|type-by-qname|uri-by-index|value-by-index|value-by-namespace-name|value-by-qname|wait-state?|wait-sta?|wait-s?|wait))\\s*(?=\\()",
       "beginCaptures": {
         "1": {
           "name": "punctuation.separator.colon.abl"
@@ -4776,7 +4775,7 @@
       ]
     },
     "handle-methods-I": {
-      "begin": "(?i)(:)((index-info(?:rmation|rmatio|rmati|rmat|rma|rm|r)?)|(insert-b(?:acktab|ackta|ackt|ack|ac|a)?)|(insert-t(?:ab|a)?)|import-node|import-principal|increment-exclusive-id|initialize|initialize-document-type|initiate|insert|insert-attribute|insert-before|insert-file|insert-row|insert-string|invoke|is-row-selected|is-selected)\\s*(?=\\()",
+      "begin": "(?i)(:)(i(?:mport-node|mport-principal|ncrement-exclusive-id|ndex-information?|ndex-informati?|ndex-informa?|ndex-infor?|nitialize|nitialize-document-type|nitiate|nsert|nsert-attribute|nsert-backtab?|nsert-backt?|nsert-bac?|nsert-b|nsert-before|nsert-file|nsert-row|nsert-string|nsert-tab?|nsert-t|nvoke|s-row-selected|s-selected))\\s*(?=\\()",
       "beginCaptures": {
         "1": {
           "name": "punctuation.separator.colon.abl"
@@ -4798,7 +4797,7 @@
       ]
     },
     "handle-methods-L": {
-      "begin": "(?i)(:)((load-mouse-p(?:ointer|ointe|oint|oin|oi|o)?)|last-of|list-property-names|load|load-domains|load-icon|load-image|load-image-down|load-image-insensitive|load-image-up|load-small-icon|lock-registration|log-audit-event|logout|longchar-to-node-value|lookup|)\\s*(?=\\()",
+      "begin": "(?i)(:)(l(?:ast-of|ist-property-names|oad|oad-domains|oad-icon|oad-image|oad-image-down|oad-image-insensitive|oad-image-up|oad-mouse-pointer?|oad-mouse-point?|oad-mouse-poi?|oad-mouse-p|oad-small-icon|ock-registration|og-audit-event|ogout|ongchar-to-node-value|ookup))\\s*(?=\\()",
       "beginCaptures": {
         "1": {
           "name": "punctuation.separator.colon.abl"
@@ -4820,7 +4819,7 @@
       ]
     },
     "handle-methods-M": {
-      "begin": "(?i)(:)((move-after(?:-tab-item|-tab-ite|-tab-it|-tab-i|-tab-|-tab|-ta|-t|-)?)|(move-befor(?:e-tab-item|e-tab-ite|e-tab-it|e-tab-i|e-tab-|e-tab|e-ta|e-t|e-|e)?)|(move-col(?:umn|um|u)?)|(move-to-b(?:ottom|otto|ott|ot|o)?)|(move-to-t(?:op|o)?)|mark-new|mark-row-state|memptr-to-node-value|merge-changes|merge-row-changes|move-to-eof)\\s*(?=\\()",
+      "begin": "(?i)(:)(m(?:ark-new|ark-row-state|emptr-to-node-value|erge-changes|erge-row-changes|ove-after-tab-item?|ove-after-tab-it?|ove-after-tab-?|ove-after-ta?|ove-after-?|ove-before-tab-item?|ove-before-tab-it?|ove-before-tab-?|ove-before-ta?|ove-before-?|ove-befor|ove-column?|ove-colu?|ove-to-bottom?|ove-to-bott?|ove-to-bo?|ove-to-eof|ove-to-top?|ove-to-t))\\s*(?=\\()",
       "beginCaptures": {
         "1": {
           "name": "punctuation.separator.colon.abl"
@@ -4842,7 +4841,7 @@
       ]
     },
     "handle-methods-N": {
-      "begin": "(?i)(:)(node-value-to-longchar|node-value-to-memptr|normalize)\\s*(?=\\()",
+      "begin": "(?i)(:)(no(?:de-value-to-longchar|de-value-to-memptr|rmalize))\\s*(?=\\()",
       "beginCaptures": {
         "1": {
           "name": "punctuation.separator.colon.abl"
@@ -4864,7 +4863,7 @@
       ]
     },
     "handle-methods-Q": {
-      "begin": "(?i)(:)(query-close|query-open|query-prepare)\\s*(?=\\()",
+      "begin": "(?i)(:)(query-(?:close|open|prepare))\\s*(?=\\()",
       "beginCaptures": {
         "1": {
           "name": "punctuation.separator.colon.abl"
@@ -4886,7 +4885,7 @@
       ]
     },
     "handle-methods-R": {
-      "begin": "(?i)(:)((remove-events-proc(?:edure|edur|edu|ed|e)?)|(remove-super-proc(?:edure|edur|edu|ed|e)?)|raw-transfer|read|read-file|read-json|read-xml|read-xmlschema|refresh|refresh-audit-policy|register-domain|reject-changes|reject-row-changes|remove-attribute|remove-child|replace|replace-child|replace-selection-text|reposition-to-row|reposition-to-rowid|reset||)\\s*(?=\\()",
+      "begin": "(?i)(:)(r(?:aw-transfer|ead|ead-file|ead-json|ead-xml|ead-xmlschema|efresh|efresh-audit-policy|egister-domain|eject-changes|eject-row-changes|emove-attribute|emove-child|emove-events-procedure?|emove-events-procedu?|emove-events-proce?|emove-super-procedure?|emove-super-procedu?|emove-super-proce?|eplace|eplace-child|eplace-selection-text|eposition-to-row|eposition-to-rowid|eset))\\s*(?=\\()",
       "beginCaptures": {
         "1": {
           "name": "punctuation.separator.colon.abl"
@@ -4908,7 +4907,7 @@
       ]
     },
     "handle-methods-S": {
-      "begin": "(?i)(:)((scroll-to-i(?:tem|te|t)?)|(set-blue(?:-value|-valu|-val|-va|-v|-)?)|(set-green(?:-value|-valu|-val|-va|-v|-)?)|(set-numeric-form(?:at|a)?)|(set-red(?:-value|-valu|-val|-va|-v|-)?)|(set-rgb(?:-value|-valu|-val|-va|-v|-)?)|(set-wait(?:-state|-stat|-sta|-st|-s|-)?)|save|save-file|save-row-changes|sax-parse|sax-parse-first|sax-parse-next|scroll-to-current-row|scroll-to-selected-row|seal|search|select-all|select-focused-row|select-next-row|select-prev-row|select-row|serialize-row|set-actor|set-appl-context|set-attribute|set-attribute-node|set-break|set-buffers|set-callback|set-callback-procedure|set-client|set-commit|set-connect-procedure|set-dynamic|set-input-source|set-must-understand|set-node|set-output-destination|set-parameter|set-property|set-read-response-procedure|set-repositioned-row|set-role|set-rollback|set-safe-user|set-selection|set-serialized|set-socket-option|set-sort-arrow|start-document|start-element|stop-parsing|string-value|synchronize)\\s*(?=\\()",
+      "begin": "(?i)(:)(s(?:ave|ave-file|ave-row-changes|ax-parse|ax-parse-first|ax-parse-next|croll-to-current-row|croll-to-item?|croll-to-it?|croll-to-selected-row|eal|earch|elect-all|elect-focused-row|elect-next-row|elect-prev-row|elect-row|erialize-row|et-actor|et-appl-context|et-attribute|et-attribute-node|et-blue-value?|et-blue-val?|et-blue-v?|et-blue|et-break|et-buffers|et-callback|et-callback-procedure|et-client|et-commit|et-connect-procedure|et-dynamic|et-green-value?|et-green-val?|et-green-v?|et-green|et-input-source|et-must-understand|et-node|et-numeric-format?|et-numeric-form|et-output-destination|et-parameter|et-property|et-read-response-procedure|et-red-value?|et-red-val?|et-red-v?|et-red|et-repositioned-row|et-rgb-value?|et-rgb-val?|et-rgb-v?|et-rgb|et-role|et-rollback|et-safe-user|et-selection|et-serialized|et-socket-option|et-sort-arrow|et-wait-state?|et-wait-sta?|et-wait-s?|et-wait|tart-document|tart-element|top-parsing|tring-value|ynchronize))\\s*(?=\\()",
       "beginCaptures": {
         "1": {
           "name": "punctuation.separator.colon.abl"
@@ -4930,7 +4929,7 @@
       ]
     },
     "handle-methods-T": {
-      "begin": "(?i)(:)((temp-table-prepar(?:e)?)|tenant-id|tenant-name)\\s*(?=\\()",
+      "begin": "(?i)(:)(te(?:mp-table-prepare?|nant-id|nant-name))\\s*(?=\\()",
       "beginCaptures": {
         "1": {
           "name": "punctuation.separator.colon.abl"
@@ -4952,7 +4951,7 @@
       ]
     },
     "handle-methods-U": {
-      "begin": "(?i)(:)(update-attribute|url-decode|url-encode|user-data)\\s*(?=\\()",
+      "begin": "(?i)(:)(u(?:pdate-attribute|rl-decode|rl-encode|ser-data))\\s*(?=\\()",
       "beginCaptures": {
         "1": {
           "name": "punctuation.separator.colon.abl"
@@ -4974,7 +4973,7 @@
       ]
     },
     "handle-methods-V": {
-      "begin": "(?i)(:)(validate|validate-domain-access-code|validate-seal)\\s*(?=\\()",
+      "begin": "(?i)(:)(validate(?:|-domain-access-code|-seal))\\s*(?=\\()",
       "beginCaptures": {
         "1": {
           "name": "punctuation.separator.colon.abl"
@@ -4996,7 +4995,7 @@
       ]
     },
     "handle-methods-W": {
-      "begin": "(?i)(:)(write|write-cdata|write-characters|write-comment|write-data|write-data-element|write-empty-element|write-entity-ref|write-external-dtd|write-fragment|write-json|write-message|write-processing-instruction|write-xml|write-xmlschema)\\s*(?=\\()",
+      "begin": "(?i)(:)(write(?:|-cdata|-characters|-comment|-data|-data-element|-empty-element|-entity-ref|-external-dtd|-fragment|-json|-message|-processing-instruction|-xml|-xmlschema))\\s*(?=\\()",
       "beginCaptures": {
         "1": {
           "name": "punctuation.separator.colon.abl"
@@ -5092,7 +5091,7 @@
     },
     "abl-functions-A": {
       "name": "meta.function-call.abl",
-      "begin": "(?i)\\s*((abs(?:olute|olut|olu|ol|o)?)|(accum(?:ulate|ulat|ula|ul|u)?)|(ambig(?:uous|uou|uo|u)?)|(asc(?:ending|endin|endi|end|en|e)?)|(avail(?:able|abl|ab|a)?)|add-interval|alias|audit-enabled)\\s*(?=\\()",
+      "begin": "(?i)\\s*(a(?:bsolute?|bsolu?|bso?|ccumulate?|ccumula?|ccumu?|dd-interval|lias|mbiguous?|mbiguo?|mbig|scending?|scendi?|scen?|sc|udit-enabled|vailable?|vailab?|vail))\\s*(?=\\()",
       "beginCaptures": {
         "1": {
           "name": "support.function.abl"
@@ -5112,7 +5111,7 @@
     },
     "abl-functions-B": {
       "name": "meta.function-call.abl",
-      "begin": "(?i)\\s*(base64-decode|base64-encode|box|buffer-group-id|buffer-group-name|buffer-partition-id|buffer-tenant-id|buffer-tenant-name)\\s*(?=\\()",
+      "begin": "(?i)\\s*(b(?:ase64-decode|ase64-encode|ox|uffer-group-id|uffer-group-name|uffer-partition-id|uffer-tenant-id|uffer-tenant-name))\\s*(?=\\()",
       "beginCaptures": {
         "1": {
           "name": "support.function.abl"
@@ -5132,7 +5131,7 @@
     },
     "abl-functions-C": {
       "name": "meta.function-call.abl",
-      "begin": "(?i)\\s*((compare(?:s)?)|(current-lang(?:uage|uag|ua|u)?)|can-do|can-find|can-query|can-set|caps|cast|chr|codepage-convert|connected|count-of|current-changed|current-result-row|current-value)\\s*(?=\\()",
+      "begin": "(?i)\\s*(c(?:an-do|an-find|an-query|an-set|aps|ast|hr|odepage-convert|ompares?|onnected|ount-of|urrent-changed|urrent-language?|urrent-langua?|urrent-lang|urrent-result-row|urrent-value))\\s*(?=\\()",
       "beginCaptures": {
         "1": {
           "name": "support.function.abl"
@@ -5152,7 +5151,7 @@
     },
     "abl-functions-D": {
       "name": "meta.function-call.abl",
-      "begin": "(?i)\\s*((dbrest(?:rictions|riction|rictio|ricti|rict|ric|ri|r)?)|(dbvers(?:ion|io|i)?)|(dec(?:imal|ima|im|i)?)|(dynamic-func(?:tion|tio|ti|t)?)|data-source-modified|dataservers|date|datetime|datetime-tz|day|db-remote-host|dbcodepage|dbcollation|dbname|dbparam|dbtaskid|dbtype|decrypt|defined|dynamic-cast|dynamic-current-value|dynamic-enum|dynamic-invoke|dynamic-next-value|dynamic-property)\\s*(?=\\()",
+      "begin": "(?i)\\s*(d(?:ataservers|ata-source-modified|ate|atetime|atetime-tz|ay|bcodepage|bcollation|bname|bparam|b-remote-host|brestrictions?|brestrictio?|brestrict?|brestri?|brest|btaskid|btype|bversion?|bversi?|ecimal?|ecim?|ec|ecrypt|efined|ynamic-cast|ynamic-current-value|ynamic-enum|ynamic-function?|ynamic-functi?|ynamic-func|ynamic-invoke|ynamic-next-value|ynamic-property))\\s*(?=\\()",
       "beginCaptures": {
         "1": {
           "name": "support.function.abl"
@@ -5172,7 +5171,7 @@
     },
     "abl-functions-E": {
       "name": "meta.function-call.abl",
-      "begin": "(?i)\\s*(encode|encrypt|entered|entry|error|etime|exp|extent)\\s*(?=\\()",
+      "begin": "(?i)\\s*(e(?:ncode|ncrypt|ntered|ntry|rror|time|xp|xtent))\\s*(?=\\()",
       "beginCaptures": {
         "1": {
           "name": "support.function.abl"
@@ -5192,7 +5191,7 @@
     },
     "abl-functions-F": {
       "name": "meta.function-call.abl",
-      "begin": "(?i)\\s*((frame-inde(?:x)?)|(frame-val(?:ue|u)?)|fill|first|first-of|frame-col|frame-db|frame-down|frame-field|frame-file|frame-line|frame-name|frame-row)\\s*(?=\\()",
+      "begin": "(?i)\\s*(f(?:ill|irst|irst-of|rame-col|rame-db|rame-down|rame-field|rame-file|rame-index?|rame-line|rame-name|rame-row|rame-value?|rame-val))\\s*(?=\\()",
       "beginCaptures": {
         "1": {
           "name": "support.function.abl"
@@ -5212,7 +5211,7 @@
     },
     "abl-functions-G": {
       "name": "meta.function-call.abl",
-      "begin": "(?i)\\s*((gateway(?:s)?)|(get-codepage(?:s)?)|(get-codepage(?:s)?)|(get-coll(?:ations|ation|atio|ati|at|a)?)|(go-pend(?:ing|in|i)?)|generate-pbe-key|generate-pbe-salt|generate-random-key|generate-uuid|get-bits|get-byte|get-byte-order|get-bytes|get-class|get-collation|get-db-client|get-double|get-effective-tenant-id|get-effective-tenant-name|get-float|get-int64|get-long|get-pointer-value|get-short|get-size|get-string|get-unsigned-long|get-unsigned-short|guid)\\s*(?=\\()",
+      "begin": "(?i)\\s*(g(?:ateways?|enerate-pbe-key|enerate-pbe-salt|enerate-random-key|enerate-uuid|et-bits|et-byte|et-byte-order|et-bytes|et-class|et-codepages?|et-codepages?|et-collations??|et-collation?|et-collati?|et-colla?|et-db-client|et-double|et-effective-tenant-id|et-effective-tenant-name|et-float|et-int64|et-long|et-pointer-value|et-short|et-size|et-string|et-unsigned-long|et-unsigned-short|o-pending?|o-pendi?|uid))\\s*(?=\\()",
       "beginCaptures": {
         "1": {
           "name": "support.function.abl"
@@ -5232,7 +5231,7 @@
     },
     "abl-functions-H": {
       "name": "meta.function-call.abl",
-      "begin": "(?i)\\s*(handle|hash-code|hex-decode|hex-encode)\\s*(?=\\()",
+      "begin": "(?i)\\s*(h(?:andle|ash-code|ex-decode|ex-encode))\\s*(?=\\()",
       "beginCaptures": {
         "1": {
           "name": "support.function.abl"
@@ -5252,7 +5251,7 @@
     },
     "abl-functions-I": {
       "name": "meta.function-call.abl",
-      "begin": "(?i)\\s*((int(?:eger|ege|eg|e)?)|(is-attr(?:-space|-spac|-spa|-sp|-s|-)?)|index|input|int64|interval|is-codepage-fixed|is-column-codepage|is-db-multi-tenant|is-lead-byte|iso-date)\\s*(?=\\()",
+      "begin": "(?i)\\s*(i(?:ndex|nput|nt64|nteger?|nteg?|nt|nterval|s-attr-space?|s-attr-spa?|s-attr-s?|s-attr|s-codepage-fixed|s-column-codepage|s-db-multi-tenant|s-lead-byte|so-date))\\s*(?=\\()",
       "beginCaptures": {
         "1": {
           "name": "support.function.abl"
@@ -5272,7 +5271,7 @@
     },
     "abl-functions-K": {
       "name": "meta.function-call.abl",
-      "begin": "(?i)\\s*((keyfunc(?:tion|tio|ti|t)?)|kblabel|keycode|keylabel|keyword|keyword-all)\\s*(?=\\()",
+      "begin": "(?i)\\s*(k(?:blabel|eycode|eyfunction?|eyfuncti?|eyfunc|eylabel|eyword|eyword-all))\\s*(?=\\()",
       "beginCaptures": {
         "1": {
           "name": "support.function.abl"
@@ -5292,7 +5291,7 @@
     },
     "abl-functions-L": {
       "name": "meta.function-call.abl",
-      "begin": "(?i)\\s*((line-count(?:er|e)?)|last|last-of|lastkey|lc|ldbname|left-trim|length|library|list-events|list-query-attrs|list-set-attrs|list-widgets|locked|log|logical|lookup|lower)\\s*(?=\\()",
+      "begin": "(?i)\\s*(last|lastkey|last-of|lc|ldbname|left-trim|length|library|line-counter?|line-count|list-events|list-query-attrs|list-set-attrs|list-widgets|locked|log|(log(?:i(?:cal?|c?))?)|lo?|(longch(?:ar?)?)|lookup|lower)\\s*(?=\\()",
       "beginCaptures": {
         "1": {
           "name": "support.function.abl"
@@ -5312,7 +5311,7 @@
     },
     "abl-functions-M": {
       "name": "meta.function-call.abl",
-      "begin": "(?i)\\s*((min(?:imum|imu|im|i)?)|maximum|md5-digest|member|message-digest|message-lines|month|mtime)\\s*(?=\\()",
+      "begin": "(?i)\\s*(m(?:aximum|d5-digest|ember|essage-digest|essage-lines|inimum?|inim?|in|onth|time))\\s*(?=\\()",
       "beginCaptures": {
         "1": {
           "name": "support.function.abl"
@@ -5332,7 +5331,7 @@
     },
     "abl-functions-N": {
       "name": "meta.function-call.abl",
-      "begin": "(?i)\\s*((num-ali(?:ases|ase|as|a)?)|new|next-value|normalize|not|now|num-dbs|num-entries|num-results)\\s*(?=\\()",
+      "begin": "(?i)\\s*(n(?:ew|ext-value|ormalize|ot|ow|um-aliases?|um-alias?|um-ali|um-dbs|um-entries|um-results))\\s*(?=\\()",
       "beginCaptures": {
         "1": {
           "name": "support.function.abl"
@@ -5352,7 +5351,7 @@
     },
     "abl-functions-O": {
       "name": "meta.function-call.abl",
-      "begin": "(?i)\\s*((os-drive(?:s)?)|opsys|os-dir|os-error|os-getenv)\\s*(?=\\()",
+      "begin": "(?i)\\s*(o(?:psys|s-drives?|s-error|s-getenv|s-dir))\\s*(?=\\()",
       "beginCaptures": {
         "1": {
           "name": "support.function.abl"
@@ -5372,7 +5371,7 @@
     },
     "abl-functions-P": {
       "name": "meta.function-call.abl",
-      "begin": "(?i)\\s*((page-num(?:ber|be|b)?)|(proc-ha(?:ndle|ndl|nd|n)?)|(proc-st(?:atus|atu|at|a)?)|(provers(?:ion|io|i)?)|page-size|pdbname|process-architecture|program-name|progress|promsgs|propath)\\s*(?=\\()",
+      "begin": "(?i)\\s*(p(?:age-number?|age-numb?|age-size|dbname|roc-handle?|roc-hand?|roc-ha|roc-status?|roc-stat?|roc-st|rocess-architecture|rogram-name|rogress|romsgs|ropath|roversion?|roversi?))\\s*(?=\\()",
       "beginCaptures": {
         "1": {
           "name": "support.function.abl"
@@ -5392,7 +5391,7 @@
     },
     "abl-functions-Q": {
       "name": "meta.function-call.abl",
-      "begin": "(?i)\\s*(query-off-end|quoter)\\s*(?=\\()",
+      "begin": "(?i)\\s*(qu(?:ery-off-end|oter))\\s*(?=\\()",
       "beginCaptures": {
         "1": {
           "name": "support.function.abl"
@@ -5412,7 +5411,7 @@
     },
     "abl-functions-R": {
       "name": "meta.function-call.abl",
-      "begin": "(?i)\\s*((record-len(?:gth|gt|g)?)|(relation-fi(?:elds|eld|el|e)?)|(return-val(?:ue|u)?)|(rgb-v(?:alue|alu|al|a)?)|r-index|random|raw|recid|rejected|replace|retry|return|right-trim|round|row-state|rowid)\\s*(?=\\()",
+      "begin": "(?i)\\s*(r(?:elation-fields?|elation-fiel?|elation-fi|-index|andom|aw|ecid|ecord-length?|ecord-leng?|ejected|eplace|etry|eturn-value?|eturn-val|gb-value?|gb-val?|gb-v|ight-trim|ound|ow-state|owid|eturn))\\s*(?=\\()",
       "beginCaptures": {
         "1": {
           "name": "support.function.abl"
@@ -5432,7 +5431,7 @@
     },
     "abl-functions-S": {
       "name": "meta.function-call.abl",
-      "begin": "(?i)\\s*((setuser(?:id|i)?)|(subst(?:itute|itut|itu|it|i)?)|(substr(?:ing|in|i)?)|screen-lines|sdbname|search|seek|set-db-client|set-effective-tenant|set-size|sha1-digest|skip|sqrt|ssl-server-name|string|super)\\s*(?=\\()",
+      "begin": "(?i)\\s*(s(?:creen-lines|dbname|earch|eek|et-db-client|et-effective-tenant|et-size|etuserid?|etuser|ha1-digest|qrt|sl-server-name|tring|ubstitute?|ubstitu?|ubsti?|ubstring?|ubstri?|uper|kip))\\s*(?=\\()",
       "beginCaptures": {
         "1": {
           "name": "support.function.abl"
@@ -5452,7 +5451,7 @@
     },
     "abl-functions-T": {
       "name": "meta.function-call.abl",
-      "begin": "(?i)\\s*((transact(?:ion|io|i)?)|(trunc(?:ate|at|a)?)|tenant-id|tenant-name|tenant-name-to-id|terminal|this-object|time|timezone|to-rowid|today|trim|type-of)\\s*(?=\\()",
+      "begin": "(?i)\\s*(t(?:enant-id|enant-name|enant-name-to-id|erminal|ime|imezone|oday|o-rowid|ransaction?|ransacti?|rim|runcate?|runca?|ype-of|his-object))\\s*(?=\\()",
       "beginCaptures": {
         "1": {
           "name": "support.function.abl"
@@ -5472,7 +5471,7 @@
     },
     "abl-functions-U": {
       "name": "meta.function-call.abl",
-      "begin": "(?i)\\s*(unbox|userid)\\s*(?=\\()",
+      "begin": "(?i)\\s*(u(?:nbox|serid))\\s*(?=\\()",
       "beginCaptures": {
         "1": {
           "name": "support.function.abl"
@@ -5492,7 +5491,7 @@
     },
     "abl-functions-V": {
       "name": "meta.function-call.abl",
-      "begin": "(?i)\\s*(valid-event|valid-handle|valid-object|value)\\s*(?=\\()",
+      "begin": "(?i)\\s*(val(?:ue|id-event|id-handle|id-object))\\s*(?=\\()",
       "beginCaptures": {
         "1": {
           "name": "support.function.abl"
@@ -5512,7 +5511,7 @@
     },
     "abl-functions-W": {
       "name": "meta.function-call.abl",
-      "begin": "(?i)\\s*((widget-h(?:andle|andl|and|an|a)?)|weekday)\\s*(?=\\()",
+      "begin": "(?i)\\s*(w(?:eekday|idget-handle?|idget-hand?|idget-ha?))\\s*(?=\\()",
       "beginCaptures": {
         "1": {
           "name": "support.function.abl"

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,9 @@
       "name": "abl-tmlanguage",
       "version": "1.3.11",
       "license": "MIT",
+      "dependencies": {
+        "oniguruma-parser": "^0.12.0"
+      },
       "devDependencies": {
         "chai": "^4.2.0",
         "mocha": "^10.2.0",
@@ -707,6 +710,11 @@
       "dependencies": {
         "wrappy": "1"
       }
+    },
+    "node_modules/oniguruma-parser": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/oniguruma-parser/-/oniguruma-parser-0.12.0.tgz",
+      "integrity": "sha512-fD9o5ebCmEAA9dLysajdQvuKzLL7cj+w7DQjuO3Cb6IwafENfx6iL+RGkmyW82pVRsvgzixsWinHvgxTMJvdIA=="
     },
     "node_modules/p-limit": {
       "version": "3.1.0",

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "1.3.11",
   "description": "TextMate grammar for Progress OpenEdge ABL Language",
   "main": "",
+  "type": "commonjs",
   "repository": {
     "type": "git",
     "url": "git@github.com:chriscamicas/abl-tmlanguage.git"
@@ -14,7 +15,7 @@
   },
   "homepage": "https://github.com/chriscamicas/abl-tmlanguage",
   "scripts": {
-    "build": "node index.js",
+    "build": "node index.mjs",
     "test": "mocha spec/*/*.spec.js",
     "test:single": "mocha",
     "test:debug": "mocha 'spec/*/*.spec.js' -- --inspect-brk=5858"
@@ -25,5 +26,8 @@
     "mocha": "^10.2.0",
     "vscode-oniguruma": "^1.6.2",
     "vscode-textmate": "^7.0.4"
+  },
+  "dependencies": {
+    "oniguruma-parser": "^0.12.0"
   }
 }


### PR DESCRIPTION
Use the optimiser from oniguruma-parser to optimise the regexes for the various keywords, functions and methods.

This (apparently, to me, a JS noob) must be done using `import` not `require` so the index file is renamed to support a mix of classic JS and modules.