### PR TITLE
fix: paths with more than one . in them

### DIFF
--- a/abl.tmLanguage.json
+++ b/abl.tmLanguage.json
@@ -3611,7 +3611,7 @@
     "include-file": {
       "name": "meta.include.abl",
       "comment": "https://docs.progress.com/bundle/abl-reference/page/Include-file-reference.html. Filesystem names can be unicode",
-      "begin": "({)\\s*(['\"]?([\\\\\\/\\w$\\-]+)(\\.[\\w]+['\"]?)?)",
+      "begin": "({)\\s*(['\"]?([\\\\\\/\\w$\\-\\.]+)(\\.[\\w]+['\"]?)?)",
       "beginCaptures": {
         "1": {
           "name": "punctuation.section.abl"


### PR DESCRIPTION
diff without JSON escaping slashes:
```diff
-({)\s*(['"]?([\\\/\w$\-]+)(\.[\w]+['"]?)?)
+({)\s*(['"]?([\\\/\w$\-\.]+)(\.\w+['"]?)?)
```
should fix this: https://github.com/vscode-abl/vscode-abl/issues/362
regex101 with mentioned include statements: https://regex101.com/r/RtsoMD/1